### PR TITLE
Switches, Cancel Button, and Context Menu options

### DIFF
--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/AppLaunch.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/AppLaunch.java
@@ -416,7 +416,7 @@ public class AppLaunch extends AppCompatActivity {
 
             // Look through the event rows to find a match
             for (int i = 0; i < event_list.size(); i++) {
-                if (event_list.get(i).description.equals(in_EventDescription)) {
+                if (event_list.get(i).description.equals(in_EventDescription) && event_list.get(i).match_phase.equals(Match.matchPhase)) {
                     ret = event_list.get(i).id;
                     break;
                 }

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/Match.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/Match.java
@@ -309,7 +309,6 @@ public class Match extends AppCompatActivity {
                 events_al = AppLaunch.EventList.getNextEvents(eventPrevious);
                 if (events_al == null) events_al = AppLaunch.EventList.getEventsForPhase(matchPhase);
             }
-            events_al.add(getResources().getString(R.string.context_menu_cancel));
             events = new String[events_al.size()];
             events = events_al.toArray(events);
             // Add all the events
@@ -321,11 +320,9 @@ public class Match extends AppCompatActivity {
 
     @Override
     public boolean onContextItemSelected(@NonNull MenuItem item) {
-        if (item.getTitle() != getResources().getString(R.string.context_menu_cancel)) {
-            matchBinding.textClickXY.setText(item.getTitle());
-            eventPrevious = AppLaunch.EventList.getEventId((String) item.getTitle());
-            // Log the event
-        }
+        matchBinding.textClickXY.setText(item.getTitle());
+        eventPrevious = AppLaunch.EventList.getEventId((String) item.getTitle());
+        // Log the event
         return true;
     }
 

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/Match.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/Match.java
@@ -224,6 +224,8 @@ public class Match extends AppCompatActivity {
         ViewGroup.LayoutParams switch_Defense_LP = new ViewGroup.LayoutParams(360, 100);
         switch_Defense.setLayoutParams(switch_Defense_LP);
         switch_Defense.setBackgroundColor(BUTTON_COLOR_NORMAL);
+        // Do this so that you can't mess with the switch during the wrong phases
+        switch_Defense.setEnabled(false);
 
         switch_Defense.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -240,8 +242,6 @@ public class Match extends AppCompatActivity {
                 }
             }
         });
-        // Do this so that you can't mess with the switch during the wrong phases
-        switch_Defense.setClickable(false);
 
         // Map the Defended Switch to the actual switch
         switch_Defended = matchBinding.switchDefended;
@@ -255,6 +255,8 @@ public class Match extends AppCompatActivity {
         ViewGroup.LayoutParams switch_Defended_LP = new ViewGroup.LayoutParams(360, 100);
         switch_Defended.setLayoutParams(switch_Defended_LP);
         switch_Defended.setBackgroundColor(BUTTON_COLOR_NORMAL);
+        // Do this so that you can't mess with the switch during the wrong phases
+        switch_Defended.setEnabled(false);
 
         switch_Defended.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -271,8 +273,6 @@ public class Match extends AppCompatActivity {
                 }
             }
         });
-        // Do this so that you can't mess with the switch during the wrong phases
-        switch_Defended.setClickable(false);
 
         // Define a context menu
         RelativeLayout ContextMenu = matchBinding.ContextMenu;
@@ -352,10 +352,6 @@ public class Match extends AppCompatActivity {
         match_Timer.scheduleAtFixedRate(gametime_timertask, 0, TIMER_UPDATE_RATE);
         match_Timer.scheduleAtFixedRate(flashing_timertask, 0, BUTTON_FLASH_INTERVAL);
 
-        // Default the toggles
-        switch_Defense.setChecked(false);
-        switch_Defended.setChecked(false);
-
         // Set match Phase to be correct and Button text
         matchPhase = PHASE_AUTO;
         but_MatchControl.setText(getResources().getString(R.string.button_start_teleop));
@@ -383,11 +379,18 @@ public class Match extends AppCompatActivity {
         but_MatchControl.setText(getResources().getString(R.string.button_end_match));
         but_MatchControl.setBackgroundColor(getResources().getColor(R.color.dark_red));
 
-        // Enable the Switches
-        switch_Defense.setClickable(true);
-        switch_Defense.setTextColor(Color.BLACK);
-        switch_Defended.setClickable(true);
-        switch_Defended.setTextColor(Color.BLACK);
+        // Enabling the Switches can't be set from a non-UI thread (like withing a TimerTask
+        // that runs on a separate thread). So we need to make a Runner that will execute on the UI thread
+        // to set this.
+        Match.this.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                switch_Defense.setEnabled(true);
+                switch_Defense.setTextColor(Color.BLACK);
+                switch_Defended.setEnabled(true);
+                switch_Defended.setTextColor(Color.BLACK);
+            }
+        });
     }
 
     // =============================================================================================
@@ -414,14 +417,20 @@ public class Match extends AppCompatActivity {
         but_MatchControl.setBackgroundColor(getResources().getColor(R.color.dark_green));
         text_Time.setText("Time: " + TIMER_DEFAULT_NUM);
 
-        // Disable the Switches and make sure they are off
-        switch_Defense.setClickable(false);
-        switch_Defense.setTextColor(BUTTON_TEXT_COLOR_DISABLED);
-        switch_Defended.setClickable(false);
-        switch_Defended.setTextColor(BUTTON_TEXT_COLOR_DISABLED);
-
-        switch_Defense.setBackgroundColor(BUTTON_COLOR_NORMAL);
-        switch_Defended.setBackgroundColor(BUTTON_COLOR_NORMAL);
+        // Disabling the Switches can't be set from a non-UI thread (like withing a TimerTask
+        // that runs on a separate thread). So we need to make a Runner that will execute on the UI thread
+        // to set this.
+        Match.this.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                switch_Defense.setEnabled(false);
+                switch_Defense.setTextColor(BUTTON_TEXT_COLOR_DISABLED);
+                switch_Defense.setBackgroundColor(BUTTON_COLOR_NORMAL);
+                switch_Defended.setEnabled(false);
+                switch_Defended.setTextColor(BUTTON_TEXT_COLOR_DISABLED);
+                switch_Defended.setBackgroundColor(BUTTON_COLOR_NORMAL);
+            }
+        });
 
         // Go to the next page
         Intent GoToNextPage = new Intent(Match.this, PreMatch.class);

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/Match.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/Match.java
@@ -107,7 +107,7 @@ public class Match extends AppCompatActivity {
     // =============================================================================================
     private MatchBinding matchBinding;
     public static long startTime;
-    private static String matchPhase = PHASE_NONE;
+    public static String matchPhase = PHASE_NONE;
     private static int eventPrevious = -1;
     // Define a button that starts the match, skips to Teleop, and ends the match early
     Button but_MatchControl;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,4 @@
     <string name="loading_devices">Loading Device Data...</string>
 
     <string name="timer_label">Time: </string>
-
-    <string name="context_menu_cancel">Cancel</string>
 </resources>


### PR DESCRIPTION
Found out how to run code from a timer on the main UI. This enables the Switches to be properly disabled and taken care of at the end of a match. I got rid of the cancel button from the context menu options, because you can just click off to cancel. I fixed the Context Menu so that the correct items appear. when getting the id for an event if it was a teleop event it would get the id for the auto event because the name for them is the same (ex. In Auto: Pickup, In Teleop: Pickup).