### PR TITLE
Optimization: trim off ".0" from x, y and time values when logging

### DIFF
--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/Logger.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/Logger.java
@@ -208,8 +208,18 @@ public class Logger {
         // If this is NOT a new sequence, we need to write out the previous event id that goes with this one
         if (!in_NewSequence) prev = String.valueOf(seq_number_prev);
 
-        // Form the output line that goes in the csv file.  Round X,Y to 2 decimal places.
-        csv_line += "," + seq_number + "," + in_EventId + "," + (float) (Math.round((in_time - Match.startTime) / 100.0)) / 100.0 + "," + (float) (Math.round(in_X * 100.0)) / 100.0 + "," + (float) (Math.round(in_Y * 100.0)) / 100.0 + "," + prev;
+        // Determine string values for x, y and time. Round them to 1 decimal places.
+        // If they happen to be whole numbers, trim off the ".0"
+        String string_x = String.valueOf((float) (Math.round(in_X * 100.0)) / 100.0);
+        String string_y = String.valueOf((float) (Math.round(in_Y * 100.0)) / 100.0);
+        String string_time = String.valueOf((float) (Math.round((in_time - Match.startTime) / 100.0)) / 100.0);
+
+        if (string_x.endsWith(".0")) string_x = string_x.substring(0, string_x.length() - 2);
+        if (string_y.endsWith(".0")) string_y = string_y.substring(0, string_y.length() - 2);
+        if (string_time.endsWith(".0")) string_time = string_time.substring(0, string_time.length() - 2);
+
+        // Form the output line that goes in the csv file.
+        csv_line += "," + seq_number + "," + in_EventId + "," + string_time + "," + string_x + "," + string_y + "," + prev;
         try {
             fos_event.write(csv_line.getBytes(StandardCharsets.UTF_8));
             fos_event.write(System.lineSeparator().getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
fixes #186 