### PR TITLE
Max Time, End of Toggles, and text_Time text fix

### DIFF
--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/Logger.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/Logger.java
@@ -221,7 +221,7 @@ public class Logger {
         if (string_x.endsWith(".0")) string_x = string_x.substring(0, string_x.length() - 2);
         if (string_y.endsWith(".0")) string_y = string_y.substring(0, string_y.length() - 2);
         if (string_time.endsWith(".0")) string_time = string_time.substring(0, string_time.length() - 2);
-
+        
         // Form the output line that goes in the csv file.
         csv_line += "," + seq_number + "," + in_EventId + "," + string_time + "," + string_x + "," + string_y + "," + prev;
         try {

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/Logger.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/Logger.java
@@ -202,7 +202,7 @@ public class Logger {
                 seq_number_prev_common = ++seq_number;
         }
 
-        String prev="";
+        String prev = "";
         String csv_line = Globals.CurrentCompetitionId + ":" + Globals.CurrentMatchNumber + ":" + Globals.CurrentDeviceId;
 
         // If this is NOT a new sequence, we need to write out the previous event id that goes with this one

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/Logger.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/Logger.java
@@ -1,5 +1,9 @@
 package com.cpr3663.cpr_scouting_app;
 
+import android.content.Context;
+import android.os.Environment;
+import android.util.Pair;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -8,10 +12,6 @@ import java.nio.file.Files;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
-
-import android.content.Context;
-import android.os.Environment;
-import android.util.Pair;
 
 // =============================================================================================
 // Class:       Logger
@@ -206,7 +206,9 @@ public class Logger {
         if (!in_NewSequence) prev = String.valueOf(seq_number_prev);
 
         // Form the output line that goes in the csv file.  Round X,Y to 2 decimal places.
-        csv_line += "," + seq_number + "," + in_EventId + "," + (float) (Math.round((in_time - Match.startTime) / 100.0)) / 100.0 + "," + (float) (Math.round(in_X * 100.0)) / 100.0 + "," + (float) (Math.round(in_Y * 100.0)) / 100.0 + "," + prev;
+        double elapsed_secs = Math.round((in_time - Match.startTime) / 10.0) / 100.0;
+        elapsed_secs = Math.min(elapsed_secs, Match.TIMER_AUTO_LENGTH + Match.TIMER_TELEOP_LENGTH);
+        csv_line += "," + seq_number + "," + in_EventId + "," + elapsed_secs + "," + (float) (Math.round(in_X * 100.0)) / 100.0 + "," + (float) (Math.round(in_Y * 100.0)) / 100.0 + "," + prev;
         try {
             fos_event.write(csv_line.getBytes(StandardCharsets.UTF_8));
             fos_event.write(System.lineSeparator().getBytes(StandardCharsets.UTF_8));

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/Match.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/Match.java
@@ -41,8 +41,8 @@ public class Match extends AppCompatActivity {
     // =============================================================================================
     // Define constants
     // =============================================================================================
-    private static final int TIMER_AUTO_LENGTH = 15; // in seconds
-    private static final int TIMER_TELEOP_LENGTH = 135; // in seconds
+    protected static final int TIMER_AUTO_LENGTH = 15; // in seconds
+    protected static final int TIMER_TELEOP_LENGTH = 135; // in seconds
     private static final int TIMER_UPDATE_RATE = 1_000; // in milliseconds
     private static final int TIMER_AUTO_TELEOP_DELAY = 3; // in seconds
     private static final int BUTTON_FLASH_INTERVAL = 1_000; // in milliseconds
@@ -212,7 +212,7 @@ public class Match extends AppCompatActivity {
         // Map the text box variable to the actual text box
         text_Time = matchBinding.textTime;
         // Initialize the match timer textbox settings
-        text_Time.setText(getString(R.string.timer_label) + TIMER_AUTO_LENGTH);
+        text_Time.setText(getString(R.string.timer_label) + " " + TIMER_AUTO_LENGTH);
         text_Time.setTextSize(20F);
         text_Time.setTextAlignment(Layout.Alignment.ALIGN_CENTER.ordinal() + 2);
         text_Time.setVisibility(View.INVISIBLE);
@@ -465,9 +465,9 @@ public class Match extends AppCompatActivity {
     public void start_Teleop() {
         // Set the start Time so that the Display Time will be correct
         startTime = System.currentTimeMillis() - TIMER_AUTO_LENGTH * 1_000;
-        text_Time.setText(getString(R.string.timer_label) + TIMER_TELEOP_LENGTH / 60 + ":" + String.format("%02d", TIMER_TELEOP_LENGTH % 60));
+        text_Time.setText(getString(R.string.timer_label) + " " + TIMER_TELEOP_LENGTH / 60 + ":" + String.format("%02d", TIMER_TELEOP_LENGTH % 60));
 
-        match_Timer.schedule(teleop_timertask, TIMER_TELEOP_LENGTH * 1_000);
+        match_Timer.schedule(teleop_timertask, TIMER_TELEOP_LENGTH * 1_000 + 3_000);
 
         // Set match Phase to be correct and Button text
         matchPhase = Constants.PHASE_TELEOP;
@@ -513,6 +513,10 @@ public class Match extends AppCompatActivity {
 
         // Reset match phase so that the next time we hit Start Match we do the right thing
         matchPhase = Constants.PHASE_NONE;
+
+        // If either of the toggles are on turn them off
+        if (switch_Defended.isChecked()) Globals.EventLogger.LogEvent(Constants.EVENT_ID_DEFENDED_END, 0, 0, false);
+        if (switch_Defense.isChecked()) Globals.EventLogger.LogEvent(Constants.EVENT_ID_DEFENSE_END, 0, 0, false);
 
         // Go to the next page
         Intent GoToPostMatch = new Intent(Match.this, PostMatch.class);

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/Match.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/Match.java
@@ -473,7 +473,7 @@ public class Match extends AppCompatActivity {
         startTime = System.currentTimeMillis() - TIMER_AUTO_LENGTH * 1_000;
         text_Time.setText(getString(R.string.timer_label) + " " + TIMER_TELEOP_LENGTH / 60 + ":" + String.format("%02d", TIMER_TELEOP_LENGTH % 60));
 
-        match_Timer.schedule(teleop_timertask, TIMER_TELEOP_LENGTH * 1_000 + 3_000);
+        match_Timer.schedule(teleop_timertask, TIMER_TELEOP_LENGTH * 1_000);
 
         // Set match Phase to be correct and Button text
         matchPhase = Constants.PHASE_TELEOP;

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/Match.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/Match.java
@@ -523,6 +523,8 @@ public class Match extends AppCompatActivity {
         // If either of the toggles are on turn them off
         if (switch_Defended.isChecked()) Globals.EventLogger.LogEvent(Constants.EVENT_ID_DEFENDED_END, 0, 0, false);
         if (switch_Defense.isChecked()) Globals.EventLogger.LogEvent(Constants.EVENT_ID_DEFENSE_END, 0, 0, false);
+        switch_Defense.setChecked(false);
+        switch_Defended.setChecked(false);
 
         // Go to the next page
         Intent GoToPostMatch = new Intent(Match.this, PostMatch.class);


### PR DESCRIPTION
Made the logger log the match length if the elapsed time is greater than it. Made the defense and defended switches do not have orphaned events if you end with them on. Fixed the bug where text_Time would sometimes not have a space in it.

Fixes #171 