### PR TITLE
Fix initial crash

### DIFF
--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/PreMatch.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/PreMatch.java
@@ -216,30 +216,14 @@ public class PreMatch extends AppCompatActivity {
                     String TeamToScoutStr = String.valueOf(edit_Team.getText());
                     if (!TeamToScoutStr.isEmpty()) {
                         int TeamToScout = Integer.parseInt(TeamToScoutStr);
-                        if (TeamToScout > 0 && TeamToScout < Globals.TeamList.size()) {
+                        // Since TeamList always has a NO_TEAM entry at index=0, need to check size-1
+                        if (TeamToScout > 0 && TeamToScout < Globals.TeamList.size() - 1) {
                             // This will crash the app instead of returning null if you pass it an invalid num
                             String ScoutingTeamName = Globals.TeamList.get(TeamToScout);
                             text_TeamName.setText(ScoutingTeamName);
                         } else {
                             text_TeamName.setText("");
                         }
-                    }
-                }
-            }
-        });
-
-        edit_Team.setOnFocusChangeListener(new View.OnFocusChangeListener() {
-            @Override
-            public void onFocusChange(View view, boolean focus) {
-                if (!focus) {
-                    String TeamToScoutStr = String.valueOf(edit_Team.getText());
-                    if (!TeamToScoutStr.isEmpty()) {
-                        int TeamToScout = Integer.parseInt(TeamToScoutStr);
-                        if (TeamToScout > 0 && TeamToScout < Globals.TeamList.size()) {
-                            // This will crash the app instead of returning null if you pass it an invalid num
-                            String ScoutingTeamName = Globals.TeamList.get(TeamToScout);
-                            text_TeamName.setText(ScoutingTeamName);
-                        } else text_TeamName.setText("");
                     }
                 }
             }

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/data/Matches.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/data/Matches.java
@@ -37,7 +37,7 @@ public class Matches {
 
     // Member Function: Get back a row of data for a given match
     public int getNumberOfMatches() {
-        return match_list.size();
+        return match_list.size() - 1;
     }
 
     // Member Function: Empties out the list


### PR DESCRIPTION
On FIRST install, there's no competition ID defined, so we load NO matches.  Since Matches always has 1 NO_MATCH entry at index=0, if you type in match=1, we do a lookup at MATCH(1) and get an OOB exception.

Removed a duplicate onFocusChange listener for edit_Team.