### PR TITLE
Team Number / Override fixes

### DIFF
--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/AppLaunch.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/AppLaunch.java
@@ -90,6 +90,9 @@ public class AppLaunch extends AppCompatActivity {
                 appLaunch_timer.cancel();
                 appLaunch_timer.purge();
 
+                // Default Globals
+                Globals.CurrentTeamOverrideNum = 0;
+
                 // Go to the first page
                 Intent GoToPreMatch = new Intent(AppLaunch.this, PreMatch.class);
                 startActivity(GoToPreMatch);

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/Globals.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/Globals.java
@@ -32,6 +32,7 @@ public class Globals {
     public static int CurrentDeviceId;
     public static int CurrentStartPosition;
     public static int CurrentColorId;
+    public static int CurrentTeamOverrideNum;
 
     public static String CheckBoxTextPadding = "       ";
 

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/Match.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/Match.java
@@ -487,6 +487,9 @@ public class Match extends AppCompatActivity {
         but_Back.setClickable(false);
         but_Back.setVisibility(View.INVISIBLE);
 
+        // Clear out the team to override (kept it in case they hit the Back button)
+        Globals.CurrentTeamOverrideNum = 0;
+
         // Show the time
         text_Time.setVisibility(View.VISIBLE);
 
@@ -552,7 +555,7 @@ public class Match extends AppCompatActivity {
     }
 
     // =============================================================================================
-    // Function:    end_match
+    // Function:    end_Teleop
     // Description: Ends teleop, but not the match so that you can still finish up
     // Output:      void
     // Parameters:  N/A


### PR DESCRIPTION
fixes #245 

handles blanking out the match,
changing the match (if we have match data)
changing the match (if we don't have match data)

handles override team (if we have match data)
handles override team (if we don't have match data)

Handle adding override team number back into spinner if you hit the "back" button from Match.

use the DROPDOWN_NO_ITEMS global for when there's no teams
