### PR TITLE
Enhanced Logging to be cached until the end "SUBMIT" plus bug fixes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.cpr3663.cpr_scouting_app"
         minSdk = 30
         targetSdk = 34
-        versionCode = 8
-        versionName = "1.1.1"
+        versionCode = 9
+        versionName = "1.2.0"
         setProperty("archivesBaseName", "CPR-Scout-$versionName")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
         </activity>
         <activity
             android:name=".Settings"
+            android:parentActivityName=".AppLaunch"
             android:screenOrientation="sensorLandscape"
             android:exported="true"
             android:noHistory="true"

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/AppLaunch.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/AppLaunch.java
@@ -106,6 +106,8 @@ public class AppLaunch extends AppCompatActivity {
                 // Go to the first page
                 Intent GoToPreMatch = new Intent(AppLaunch.this, PreMatch.class);
                 startActivity(GoToPreMatch);
+
+                finish();
             }
         });
 

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/Globals.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/Globals.java
@@ -34,6 +34,7 @@ public class Globals {
     public static int CurrentColorId;
     public static int CurrentTeamOverrideNum;
     public static int CurrentPrefTeamPos;
+    public static int CurrentTeamToScout;
 
     public static String CheckBoxTextPadding = "       ";
 

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/Match.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/Match.java
@@ -219,15 +219,19 @@ public class Match extends AppCompatActivity {
         text_Time.setBackgroundColor(Color.TRANSPARENT);
         text_Time.setTextSize(24F);
 
-        // If this is a practice, put a message in the Status
+        // If this is a practice, put a message in the Status and set the image to Practice mode
         if (Globals.isPractice) {
             matchBinding.textStatus.setTextColor(Color.YELLOW);
-            matchBinding.textStatus.setTextSize(20F);
             matchBinding.textStatus.setText(getString(R.string.status_practice));
+            matchBinding.textPractice.setText(getString(R.string.practice));
+            matchBinding.textPractice.setTextSize(210);
         } else {
             matchBinding.textStatus.setTextColor(Color.LTGRAY);
-            matchBinding.textStatus.setTextSize(16F);
+            matchBinding.textPractice.setText("");
         }
+
+        matchBinding.textTeam.setText(String.valueOf(Globals.CurrentTeamToScout) + " - " + Globals.TeamList.get(Globals.CurrentTeamToScout));
+        matchBinding.textTeam.setTextColor(Color.WHITE);
 
         // Map the button variable to the actual button
         but_MatchControl = matchBinding.butMatchControl;
@@ -287,6 +291,8 @@ public class Match extends AppCompatActivity {
                 // Go to the previous page
                 Intent GoToPreviousPage = new Intent(Match.this, PreMatch.class);
                 startActivity(GoToPreviousPage);
+
+                finish();
             }
         });
 
@@ -466,7 +472,7 @@ public class Match extends AppCompatActivity {
     @SuppressLint("SetTextI18n")
     @Override
     public boolean onContextItemSelected(@NonNull MenuItem item) {
-        if (!Globals.isPractice) matchBinding.textStatus.setText(getString(R.string.status_text_label) + Objects.requireNonNull(item.getTitle()));
+        if (!Globals.isPractice) matchBinding.textStatus.setText(getString(R.string.status_text_label) + " " + Objects.requireNonNull(item.getTitle()));
         eventPrevious = Globals.EventList.getEventId(item.getTitle().toString());
         Globals.EventLogger.LogEvent(eventPrevious, current_X_Relative, current_Y_Relative, is_start_of_seq, currentTouchTime);
         return true;
@@ -625,5 +631,7 @@ public class Match extends AppCompatActivity {
         // Go to the next page
         Intent GoToPostMatch = new Intent(Match.this, PostMatch.class);
         startActivity(GoToPostMatch);
+
+        finish();
     }
 }

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/PostMatch.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/PostMatch.java
@@ -200,6 +200,8 @@ public class PostMatch extends AppCompatActivity {
 
                 Intent GoToSubmitData = new Intent(PostMatch.this, SubmitData.class);
                 startActivity(GoToSubmitData);
+
+                finish();
             }
         });
     }

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/PreMatch.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/PreMatch.java
@@ -229,6 +229,8 @@ public class PreMatch extends AppCompatActivity {
                 if (checkbox_ReSubmit.isChecked()) {
                     Intent GoToSubmitData = new Intent(PreMatch.this, SubmitData.class);
                     startActivity(GoToSubmitData);
+
+                    finish();
                 } else {
                     // Check we have all the fields entered that are needed.  Otherwise, pop a TOAST message instead
                     if (String.valueOf(edit_Match.getText()).isEmpty() || spinner_Team.getSelectedItem().toString().equals(getString(R.string.dropdown_no_items))
@@ -244,17 +246,14 @@ public class PreMatch extends AppCompatActivity {
                         // Only if we don't have one set up already (could be there if BACK button was hit on Match)
                         // otherwise, clear out any saved data from before.
                         if (Globals.EventLogger == null) {
-                            try {
-                                Globals.EventLogger = new Logger(getApplicationContext());
-                            } catch (IOException e) {
-                                throw new RuntimeException(e);
-                            }
+                            Globals.EventLogger = new Logger(getApplicationContext());
                         } else {
                             Globals.EventLogger.clear();
                         }
 
                         // Log all of the data from this page
-                        Globals.EventLogger.LogData(Constants.LOGKEY_TEAM_TO_SCOUT, preMatchBinding.spinnerTeamToScout.getSelectedItem().toString());
+                        Globals.CurrentTeamToScout = Integer.parseInt(preMatchBinding.spinnerTeamToScout.getSelectedItem().toString());
+                        Globals.EventLogger.LogData(Constants.LOGKEY_TEAM_TO_SCOUT, String.valueOf(Globals.CurrentTeamToScout));
                         Globals.EventLogger.LogData(Constants.LOGKEY_SCOUTER, preMatchBinding.editScouterName.getText().toString().toUpperCase().replace(" ",""));
                         Globals.EventLogger.LogData(Constants.LOGKEY_DID_PLAY, String.valueOf(preMatchBinding.checkboxDidPlay.isChecked()));
                         Globals.EventLogger.LogData(Constants.LOGKEY_TEAM_SCOUTING, String.valueOf(Globals.CurrentScoutingTeam));
@@ -272,8 +271,8 @@ public class PreMatch extends AppCompatActivity {
                             Intent GoToMatch = new Intent(PreMatch.this, Match.class);
                             startActivity(GoToMatch);
                         } else {
-                            // Since we're jumping to the Submit page, we need to close the Logger first.
-                            Globals.EventLogger.close();
+                            // Since we're jumping to the Submit page, we need to clear the Logger first.
+                            Globals.EventLogger.clear();
                             Globals.EventLogger = null;
 
                             // Increases the match number so that it auto fills for the next match correctly
@@ -286,6 +285,8 @@ public class PreMatch extends AppCompatActivity {
                             Intent GoToSubmitData = new Intent(PreMatch.this, SubmitData.class);
                             startActivity(GoToSubmitData);
                         }
+
+                        finish();
                     }
                 }
             }

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/Settings.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/Settings.java
@@ -221,7 +221,7 @@ public class Settings extends AppCompatActivity {
                 Globals.CurrentPrefTeamPos = spinner_PrefTeamPos.getSelectedItemPosition();
                 Globals.spe.putInt(Constants.SP_PREF_TEAM_POS, Globals.CurrentPrefTeamPos);
                 Globals.spe.apply();
-                Exit();
+                finish();
             }
         });
 

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/Settings.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/Settings.java
@@ -187,7 +187,7 @@ public class Settings extends AppCompatActivity {
         but_Cancel.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                Exit();
+                finish();
             }
         });
 
@@ -241,10 +241,5 @@ public class Settings extends AppCompatActivity {
                 }
             }
         });
-    }
-
-    private void Exit() {
-        Intent GoBackToLaunch = new Intent(Settings.this, AppLaunch.class);
-        startActivity(GoBackToLaunch);
     }
 }

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/SubmitData.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/SubmitData.java
@@ -101,6 +101,8 @@ public class SubmitData extends AppCompatActivity {
             public void onClick(View view) {
                 Intent GoToPreMatch = new Intent(SubmitData.this, PreMatch.class);
                 startActivity(GoToPreMatch);
+
+                finish();
             }
         });
     }

--- a/app/src/main/res/layout/match.xml
+++ b/app/src/main/res/layout/match.xml
@@ -34,13 +34,28 @@
                 android:layout_height="65dp"
                 android:layout_gravity="center_vertical"/>
 
-            <TextView
-                android:id="@+id/text_Status"
+            <LinearLayout
                 android:layout_width="215dp"
-                android:layout_height="65dp"
-                android:gravity="start|center"
-                tools:textSize="20sp" />
+                android:layout_height="match_parent"
+                android:orientation="vertical">
 
+                <TextView
+                    android:id="@+id/text_Team"
+                    android:layout_width="match_parent"
+                    android:layout_height="35dp"
+                    android:gravity="start|center"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:textSize="12sp" />
+
+                <TextView
+                    android:id="@+id/text_Status"
+                    android:layout_width="match_parent"
+                    android:layout_height="35dp"
+                    android:gravity="start|center"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    tools:textSize="12sp" />
+
+            </LinearLayout>
             <Switch
                 android:id="@+id/switchNotMoving"
                 android:layout_width="150dp"
@@ -124,6 +139,18 @@
                 android:layout_width="fill_parent"
                 android:layout_height="fill_parent"
                 tools:ignore="MissingConstraints,UselessLeaf" />
+
+            <RelativeLayout
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent">
+
+                <TextView
+                    android:id="@+id/text_Practice"
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent"
+                    android:gravity="center"
+                    android:textColor="@color/transparent30_grey" />
+            </RelativeLayout>
         </FrameLayout>
     </LinearLayout>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -13,4 +13,5 @@
     <color name="transparent">#00000000</color>
     <color name="spinner_context_bkgnd">#FFBBBBBB</color>
     <color name="light_blue">#0086C3</color>
+    <color name="transparent30_grey">#4DF0F0F0</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="switch_on_defense">On\nDefense</string>
     <string name="switch_is_defended">Is\nDefended</string>
     <string name="switch_not_moving">Not\nMoving</string>
+    <string name="practice">PRACTICE</string>
 
     <string name="loading_teams">Loading Team Data…</string>
     <string name="loading_matches">Loading Match Data…</string>
@@ -25,7 +26,7 @@
     <string name="loading_colors">Loading Color Data…</string>
 
     <string name="missing_data">Please fill in all fields</string>
-    <string name="status_text_label">Last event:\n</string>
+    <string name="status_text_label">Last event:</string>
     <string name="status_practice">-=- PRACTICE MODE -=-</string>
 
     <string name="file_error_teams">Error loading teams from data file!</string>


### PR DESCRIPTION
Now all logging is Cached until Submit, when we write them out.  Quitting the app in the middle won't leave half written files.  Sets us up for a match reset easily, and an undo button.

Fixed how we call/close activities using finish() so we don't create an endless stack (of pancakes?).

That fixed the screen flipping issue.

Added the team number/name to the Match page.