### PR TITLE
We can RESET a match now!

### DIFF
--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/Logger.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/Logger.java
@@ -338,12 +338,21 @@ public class Logger {
         match_log_data.add(new Pair<>(in_Key, in_Value.trim()));
     }
 
+    // Member Function: Log a non-time based event - just store this for later.
+    public boolean LookupEvent(int in_EventId) {
+        for (LoggerEventRow ler : match_log_events) {
+            if (ler.EventId == in_EventId) return true;
+        }
+
+        return false;
+    }
+
     // =============================================================================================
     // Class:       LoggerEventRow
     // Description: Contains all data for a single log event
     // Methods:
     // =============================================================================================
-    protected class LoggerEventRow {
+    protected static class LoggerEventRow {
         int EventId;
         String LogTime;
         String X;
@@ -358,6 +367,5 @@ public class Logger {
             Y = in_Y;
             PrevSeq = in_PrevSeq;
         }
-
     }
 }

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/Match.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/Match.java
@@ -7,7 +7,6 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.hardware.SensorManager;
 import android.os.Bundle;
-import android.text.Layout;
 import android.text.SpannableString;
 import android.text.style.AbsoluteSizeSpan;
 import android.text.style.ForegroundColorSpan;
@@ -33,7 +32,6 @@ import androidx.core.view.WindowInsetsCompat;
 
 import com.cpr3663.cpr_scouting_app.data.Colors;
 import com.cpr3663.cpr_scouting_app.databinding.MatchBinding;
-import com.cpr3663.cpr_scouting_app.databinding.PreMatchBinding;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -95,7 +93,7 @@ public class Match extends AppCompatActivity {
         @Override
         public void run() {
             // Get elapsed time in seconds without decimal and round to make it more accurate and not skip numbers
-            int elapsedSeconds = 0;
+            int elapsedSeconds;
 
             if (matchPhase.equals(Constants.PHASE_AUTO)) {
                 elapsedSeconds = (int) (TIMER_AUTO_LENGTH - Math.round((System.currentTimeMillis() - startTime) / 1_000.0));
@@ -230,7 +228,7 @@ public class Match extends AppCompatActivity {
             matchBinding.textPractice.setText("");
         }
 
-        matchBinding.textTeam.setText(String.valueOf(Globals.CurrentTeamToScout) + " - " + Globals.TeamList.get(Globals.CurrentTeamToScout));
+        matchBinding.textTeam.setText(Globals.CurrentTeamToScout + " - " + Globals.TeamList.get(Globals.CurrentTeamToScout));
         matchBinding.textTeam.setTextColor(Color.WHITE);
 
         // Map the button variable to the actual button
@@ -529,8 +527,8 @@ public class Match extends AppCompatActivity {
         but_MatchControl.setBackgroundColor(getColor(R.color.dark_yellow));
         but_MatchControl.setCompoundDrawablesWithIntrinsicBounds(0, 0, R.drawable.start_teleop, 0);
 
-        if (PreMatch.checkbox_StartNote.isChecked()) {
-            Globals.EventLogger.LogEvent(Constants.EVENT_ID_AUTO_STARTNOTE, 0, 0, true);
+        // If we logged that we started with a note, then set the eventPrevious to it.
+        if (Globals.EventLogger.LookupEvent(Constants.EVENT_ID_AUTO_STARTNOTE)) {
             eventPrevious = Constants.EVENT_ID_AUTO_STARTNOTE;
         }
     }

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/PostMatch.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/PostMatch.java
@@ -51,8 +51,9 @@ public class PostMatch extends AppCompatActivity {
             return insets;
         });
 
-        // Default them to leaving
+        // Default values
         postMatchBinding.checkboxDidLeave.setChecked(true);
+        postMatchBinding.checkboxReset.setChecked(false);
 
         //Creating the single select dropdown menu for the trap outcomes
         Spinner spinner_Trap = findViewById(R.id.spinnerTrap);
@@ -175,33 +176,53 @@ public class PostMatch extends AppCompatActivity {
             public void onClick(View view) {
                 String multi_values = "";
 
-                // Log all of the data from this page
-                Globals.EventLogger.LogData(Constants.LOGKEY_DID_LEAVE_START, String.valueOf(postMatchBinding.checkboxDidLeave.isChecked()));
-                Globals.EventLogger.LogData(Constants.LOGKEY_CLIMB_POSITION, String.valueOf(Globals.ClimbPositionList.getClimbPositionId(postMatchBinding.spinnerClimbPosition.getSelectedItem().toString())));
-                Globals.EventLogger.LogData(Constants.LOGKEY_TRAP, String.valueOf(Globals.TrapResultsList.getTrapResultId(postMatchBinding.spinnerTrap.getSelectedItem().toString())));
-                String comment_sep_ID = "";
-                for (Integer comment_dropID : CommentList) {
-                    String comment = CommentArray[comment_dropID];
-                    comment_sep_ID += ":" + Globals.CommentList.getCommentId(comment);
+                // If we need to reset the match, abort it all and go back
+                if (postMatchBinding.checkboxReset.isChecked()) {
+                    Globals.EventLogger.clear();
+
+                    Intent GoToPreMatch = new Intent(PostMatch.this, PreMatch.class);
+                    startActivity(GoToPreMatch);
+                } else {
+                    // Log all of the data from this page
+                    Globals.EventLogger.LogData(Constants.LOGKEY_DID_LEAVE_START, String.valueOf(postMatchBinding.checkboxDidLeave.isChecked()));
+                    Globals.EventLogger.LogData(Constants.LOGKEY_CLIMB_POSITION, String.valueOf(Globals.ClimbPositionList.getClimbPositionId(postMatchBinding.spinnerClimbPosition.getSelectedItem().toString())));
+                    Globals.EventLogger.LogData(Constants.LOGKEY_TRAP, String.valueOf(Globals.TrapResultsList.getTrapResultId(postMatchBinding.spinnerTrap.getSelectedItem().toString())));
+                    String comment_sep_ID = "";
+                    for (Integer comment_dropID : CommentList) {
+                        String comment = CommentArray[comment_dropID];
+                        comment_sep_ID += ":" + Globals.CommentList.getCommentId(comment);
+                    }
+                    if (!comment_sep_ID.isEmpty()) comment_sep_ID = comment_sep_ID.substring(1);
+                    Globals.EventLogger.LogData(Constants.LOGKEY_COMMENTS, comment_sep_ID);
+
+                    // We're done with the logger
+                    Globals.EventLogger.close();
+                    Globals.EventLogger = null;
+
+                    // Increases the team number so that it auto fills for the next match correctly
+                    //  and do it after the logger is closed so that this can't mess the logger up
+                    Globals.CurrentMatchNumber++;
+
+                    // Reset the Saved Start position so that you have to choose it again
+                    Globals.CurrentStartPosition = 0;
+
+                    Intent GoToSubmitData = new Intent(PostMatch.this, SubmitData.class);
+                    startActivity(GoToSubmitData);
+
                 }
-                if (!comment_sep_ID.isEmpty()) comment_sep_ID = comment_sep_ID.substring(1);
-                Globals.EventLogger.LogData(Constants.LOGKEY_COMMENTS, comment_sep_ID);
-
-                // We're done with the logger
-                Globals.EventLogger.close();
-                Globals.EventLogger = null;
-
-                // Increases the team number so that it auto fills for the next match correctly
-                //  and do it after the logger is closed so that this can't mess the logger up
-                Globals.CurrentMatchNumber++;
-
-                // Reset the Saved Start position so that you have to choose it again
-                Globals.CurrentStartPosition = 0;
-
-                Intent GoToSubmitData = new Intent(PostMatch.this, SubmitData.class);
-                startActivity(GoToSubmitData);
 
                 finish();
+            }
+        });
+
+        postMatchBinding.checkboxReset.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                if (postMatchBinding.checkboxReset.isChecked()) {
+                    postMatchBinding.butNext.setText(getString(R.string.post_but_reset));
+                } else {
+                    postMatchBinding.butNext.setText(getString(R.string.post_but_submit));
+                }
             }
         });
     }

--- a/app/src/main/java/com/cpr3663/cpr_scouting_app/PreMatch.java
+++ b/app/src/main/java/com/cpr3663/cpr_scouting_app/PreMatch.java
@@ -24,8 +24,6 @@ import androidx.core.view.WindowInsetsCompat;
 import com.cpr3663.cpr_scouting_app.data.Matches;
 import com.cpr3663.cpr_scouting_app.databinding.PreMatchBinding;
 
-import java.io.IOException;
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 
 public class PreMatch extends AppCompatActivity {
@@ -35,7 +33,7 @@ public class PreMatch extends AppCompatActivity {
     private PreMatchBinding preMatchBinding;
     // To store the inputted name
     protected static String ScouterName;
-    protected static CheckBox checkbox_StartNote; // This needs to be global so that Match.java can access it
+    protected CheckBox checkbox_StartNote; // This needs to be global so that Match.java can access it
     private static final String[] Start_Positions = Globals.StartPositionList.getDescriptionList();
     public static int CurrentTeamToScoutPosition;
 
@@ -87,7 +85,7 @@ public class PreMatch extends AppCompatActivity {
         //  and set that one as selected
         int start_Pos_DropId = 0;
         for (int i = 0; i < Start_Positions.length; i++) {
-            if (Start_Positions[i] == Globals.StartPositionList.getStartPositionDescription(Globals.CurrentStartPosition)) {
+            if (Start_Positions[i].equals(Globals.StartPositionList.getStartPositionDescription(Globals.CurrentStartPosition))) {
                 start_Pos_DropId = i;
                 break;
             }
@@ -242,14 +240,10 @@ public class PreMatch extends AppCompatActivity {
                         Globals.NumberMatchFilesKept = Globals.sp.getInt(Constants.SP_NUM_MATCHES, 5);
                         CurrentTeamToScoutPosition = spinner_Team.getSelectedItemPosition();
 
-                        // Set up the Logger - if it fails, we better stop now, or we won't capture any data!
-                        // Only if we don't have one set up already (could be there if BACK button was hit on Match)
-                        // otherwise, clear out any saved data from before.
-                        if (Globals.EventLogger == null) {
-                            Globals.EventLogger = new Logger(getApplicationContext());
-                        } else {
-                            Globals.EventLogger.clear();
-                        }
+                        // Set up the Logger
+                        // null it out first in case we have one set up already (could be there if BACK button was hit on Match)
+                        Globals.EventLogger = null;
+                        Globals.EventLogger = new Logger(getApplicationContext());
 
                         // Log all of the data from this page
                         Globals.CurrentTeamToScout = Integer.parseInt(preMatchBinding.spinnerTeamToScout.getSelectedItem().toString());
@@ -261,6 +255,11 @@ public class PreMatch extends AppCompatActivity {
                             int startPos = Globals.StartPositionList.getStartPositionId(spinner_StartPos.getSelectedItem().toString());
                             Globals.EventLogger.LogData(Constants.LOGKEY_START_POSITION, String.valueOf(startPos));
                             Globals.CurrentStartPosition = startPos;
+                        }
+
+                        // Log if they started with a note
+                        if (checkbox_StartNote.isChecked()) {
+                            Globals.EventLogger.LogEvent(Constants.EVENT_ID_AUTO_STARTNOTE, 0, 0, true);
                         }
 
                         // Save off some fields for next time or later usage

--- a/app/src/main/res/layout/post_match.xml
+++ b/app/src/main/res/layout/post_match.xml
@@ -195,11 +195,27 @@
         </LinearLayout>
     </LinearLayout>
 
+    <CheckBox
+        android:id="@+id/checkbox_Reset"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="#FF5722"
+        android:gravity="bottom"
+        android:paddingStart="10dp"
+        android:paddingBottom="5dp"
+        android:layout_marginBottom="20dp"
+        android:layout_marginStart="20dp"
+        android:textSize="16sp"
+        android:text="@string/post_reset"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        tools:ignore="RtlSymmetry" />
+
     <Button
         android:id="@+id/but_Next"
         android:layout_width="175dp"
         android:layout_height="60dp"
-        android:text="Submit"
+        android:text="@string/post_but_submit"
         android:textSize="28sp"
         android:layout_marginBottom="20dp"
         android:layout_marginEnd="20dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,9 @@
     <string name="post_climb_position">Climbing position:</string>
     <string name="post_trap">Trap outcome:</string>
     <string name="post_comments">Comments:</string>
+    <string name="post_reset">Field Fault - Reset Match</string>
+    <string name="post_but_reset">Reset</string>
+    <string name="post_but_submit">Submit</string>
 
     <string name="submit_heading">Submit Scouting Data</string>
     <string name="submit_match_error">Incomplete data files found!</string>


### PR DESCRIPTION
Logger: needed a way to look up if we logged an event (like a starting note).  (explained below)

Match: cleanup of unnecessary things.  Also now look to see if a starting note was logged, rather than look across activities at a static variable (which was a memory leak)

PostMatch: added the reset match bit.

Pre-Match: removed static from checkbox (memory leak).  Always reset the logger (whether from reset match or back button.  Logger constructor does very little now and is safer to do.  Log the startingnote here instead of in Match.