### PR TITLE
fix the starting position

### DIFF
--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.team3663.scouting_app"
         minSdk = 30
         targetSdk = 34
-        versionCode = 30
-        versionName = "2.4.0"
+        versionCode = 31
+        versionName = "2.5.0"
 
         setProperty("archivesBaseName", "CPR-Scout-$versionName")
 

--- a/app/src/main/java/com/team3663/scouting_app/activities/PostMatch.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/PostMatch.java
@@ -218,9 +218,6 @@ public class PostMatch extends AppCompatActivity {
                 if (!comment_sep_ID.isEmpty()) comment_sep_ID = comment_sep_ID.substring(1);
                 Globals.EventLogger.LogData(Constants.Logger.LOGKEY_COMMENTS, comment_sep_ID);
 
-                // Reset the Saved Start position so that you have to choose it again
-                Globals.CurrentStartPosition = 0;
-
                 Intent GoToSubmitData = new Intent(PostMatch.this, SubmitData.class);
                 startActivity(GoToSubmitData);
             }

--- a/app/src/main/java/com/team3663/scouting_app/activities/PreMatch.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/PreMatch.java
@@ -34,7 +34,6 @@ public class PreMatch extends AppCompatActivity {
     // Global variables
     // =============================================================================================
     private PreMatchBinding preMatchBinding;
-    private boolean okay_to_proceed = false;
     // To store the inputted name
     protected static String ScouterName;
     private static final ArrayList<String> Start_Positions = Globals.StartPositionList.getDescriptionList();
@@ -70,7 +69,6 @@ public class PreMatch extends AppCompatActivity {
         initScouterName();
         initDidPlay();
         initStartingGamePiece();
-        initStartingPos();
         initOverride();
         initResubmit();
         initPractice();
@@ -249,29 +247,6 @@ public class PreMatch extends AppCompatActivity {
     }
 
     // =============================================================================================
-    // Function:    initStartingPos
-    // Description: Initialize the Start Position field
-    // Parameters:  void
-    // Output:      void
-    // =============================================================================================
-    private void initStartingPos() {
-        // Adds the items from the starting positions array to the list
-        ArrayAdapter<String> adp_StartPos = new ArrayAdapter<>(this, R.layout.cpr_spinner, Start_Positions);
-        adp_StartPos.setDropDownViewResource(R.layout.cpr_spinner_item);
-        preMatchBinding.spinnerStartingPosition.setAdapter(adp_StartPos);
-        // Search through the list of Start Positions till you find the one that is correct then get its position in the list
-        //  and set that one as selected
-        int start_Pos_DropId = 0;
-        for (int i = 0; i < Start_Positions.size(); i++) {
-            if (Start_Positions.get(i).equals(Globals.StartPositionList.getStartPositionDescription(Globals.CurrentStartPosition))) {
-                start_Pos_DropId = i;
-                break;
-            }
-        }
-        preMatchBinding.spinnerStartingPosition.setSelection(start_Pos_DropId);
-    }
-
-    // =============================================================================================
     // Function:    initOverride
     // Description: Initialize the Override fields
     // Parameters:  void
@@ -364,27 +339,11 @@ public class PreMatch extends AppCompatActivity {
         Globals.EventLogger.LogData(Constants.Logger.LOGKEY_TEAM_SCOUTING, String.valueOf(Globals.CurrentScoutingTeam));
         Globals.EventLogger.LogData(Constants.Logger.LOGKEY_MATCH_TYPE, Globals.MatchTypeList.getMatchTypeShortForm(Globals.CurrentMatchType));
         Globals.EventLogger.LogData(Constants.Logger.LOGKEY_SHADOW_MODE, String.valueOf(Globals.isShadowMode));
+        Globals.EventLogger.LogData(Constants.Logger.LOGKEY_START_TIME, LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyMMddHHmmss")));
+        Globals.EventLogger.LogData(Constants.Logger.LOGKEY_DID_LEAVE_START, String.valueOf(false));
+        Globals.EventLogger.LogData(Constants.Logger.LOGKEY_CLIMB_POSITION, String.valueOf(Constants.PreMatch.CLIMB_POS_DID_NOT_PLAY));
 
         Achievements.data_TeamToScout = Globals.CurrentTeamToScout;
-
-        // If the robot is playing, log the starting position the scouter chose.
-        // If not, we need to log a few items that won't be logged elsewhere
-        if (preMatchBinding.checkboxDidPlay.isChecked()) {
-            int startPos = Globals.StartPositionList.getStartPositionId(preMatchBinding.spinnerStartingPosition.getSelectedItem().toString());
-            Globals.EventLogger.LogData(Constants.Logger.LOGKEY_START_POSITION, String.valueOf(startPos));
-            Globals.CurrentStartPosition = startPos;
-        } else {
-            Globals.EventLogger.LogData(Constants.Logger.LOGKEY_START_POSITION, String.valueOf(Constants.PreMatch.START_POS_DID_NOT_PLAY));
-            Globals.EventLogger.LogData(Constants.Logger.LOGKEY_START_TIME, LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyMMddHHmmss")));
-            Globals.EventLogger.LogData(Constants.Logger.LOGKEY_DID_LEAVE_START, String.valueOf(false));
-            Globals.EventLogger.LogData(Constants.Logger.LOGKEY_CLIMB_POSITION, String.valueOf(Constants.PreMatch.CLIMB_POS_DID_NOT_PLAY));
-        }
-
-        // Log if they started with a game piece (the match hasn't started so we need to specify a "0" time
-        // or else it will log as max match time which wastes extra log characters for no benefit)
-        if (Globals.isStartingGamePiece) {
-            Globals.EventLogger.LogEvent(Constants.Events.ID_AUTO_START_GAME_PIECE, 0, 0, 0);
-        }
 
         // Save off some fields for next time or later usage
         if ((ScouterName != null) && (!ScouterName.isEmpty()) && !ScouterName.equals(String.valueOf(preMatchBinding.editScouterName.getText())))
@@ -397,9 +356,6 @@ public class PreMatch extends AppCompatActivity {
             Intent GoToMatch = new Intent(PreMatch.this, Match.class);
             startActivity(GoToMatch);
         } else {
-            // Reset the Saved Start position so that you have to choose it again
-            Globals.CurrentStartPosition = 0;
-
             Intent GoToSubmitData = new Intent(PreMatch.this, SubmitData.class);
             startActivity(GoToSubmitData);
         }
@@ -434,9 +390,7 @@ public class PreMatch extends AppCompatActivity {
             }
 
             if (String.valueOf(preMatchBinding.editMatch.getText()).isEmpty() || preMatchBinding.spinnerTeamToScout.getSelectedItem().toString().equals(getString(R.string.pre_dropdown_no_items))
-                    || preMatchBinding.spinnerTeamToScout.getSelectedItem().toString().isEmpty() || String.valueOf(preMatchBinding.editScouterName.getText()).isEmpty()
-                    || (preMatchBinding.spinnerStartingPosition.getSelectedItem().toString().equals(Globals.StartPositionList.getStartPositionDescription(Constants.Data.ID_START_POS_DEFAULT))
-                    && preMatchBinding.checkboxDidPlay.isChecked())) {
+                    || preMatchBinding.spinnerTeamToScout.getSelectedItem().toString().isEmpty() || String.valueOf(preMatchBinding.editScouterName.getText()).isEmpty()) {
                 Toast.makeText(PreMatch.this, R.string.pre_missing_data, Toast.LENGTH_SHORT).show();
                 return;
             }

--- a/app/src/main/java/com/team3663/scouting_app/config/Constants.java
+++ b/app/src/main/java/com/team3663/scouting_app/config/Constants.java
@@ -45,7 +45,6 @@ public class Constants {
     public static class PreMatch {
         public static final int NUMBER_OF_MATCH_TYPES = 4;
         public static final int DEFAULT_MATCH_TYPE = 1;
-        public static final int START_POS_DID_NOT_PLAY = 0;
         public static final int CLIMB_POS_DID_NOT_PLAY = 1;
     }
 

--- a/app/src/main/java/com/team3663/scouting_app/config/Globals.java
+++ b/app/src/main/java/com/team3663/scouting_app/config/Globals.java
@@ -35,7 +35,6 @@ public class Globals {
     public static int CurrentMatchNumber;
     public static int CurrentScoutingTeam;
     public static int CurrentDeviceId;
-    public static int CurrentStartPosition;
     public static int CurrentColorId;
     public static int CurrentTeamOverrideNum;
     public static int CurrentPrefTeamPos;

--- a/app/src/main/res/layout/pre_match.xml
+++ b/app/src/main/res/layout/pre_match.xml
@@ -234,58 +234,6 @@
             android:layout_height="35dp"
             android:orientation="horizontal">
 
-            <TextView
-                android:id="@+id/text_StartingPosition"
-                android:layout_width="350dp"
-                android:layout_height="match_parent"
-                android:gravity="end|center"
-                android:paddingEnd="50dp"
-                android:text="@string/pre_start_pos"
-                android:textColor="@color/white"
-                android:textSize="24sp"
-                android:visibility="visible"
-                tools:ignore="RtlSymmetry" />
-
-            <RelativeLayout
-                android:layout_width="350dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:orientation="horizontal">
-
-                <Spinner
-                    android:id="@+id/spinner_StartingPosition"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:background="@color/white"
-                    android:gravity="end|center"
-                    android:paddingStart="10dp"
-                    android:spinnerMode="dropdown"
-                    tools:ignore="RtlSymmetry" />
-
-                <ImageView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_alignParentEnd="true"
-                    android:layout_centerVertical="true"
-                    android:layout_gravity="center"
-                    android:paddingStart="5dp"
-                    android:paddingEnd="5dp"
-                    android:src="@drawable/cpr_drop_down_arrow"
-                    tools:ignore="ContentDescription" />
-
-            </RelativeLayout>
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="15dp"
-            android:orientation="horizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="35dp"
-            android:orientation="horizontal">
-
             <CheckBox
                 android:id="@+id/checkbox_DidPlay"
                 android:layout_width="0dp"

--- a/app/src/main/res/values/strings_match.xml
+++ b/app/src/main/res/values/strings_match.xml
@@ -21,4 +21,5 @@
     <string name="match_alert_orphanedEvent_message">The last event recorded could have following events.\nQuitting now will leave this incomplete.\nYou can still quit or go back and complete the event sequence.</string>
     <string name="match_alert_orphanedEvent_positive">Quit anyway</string>
     <string name="match_alert_orphanedEvent_negative">Return to match</string>
+    <string name="match_select_start_location">Select Starting Location</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.8.1"
+agp = "8.10.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"


### PR DESCRIPTION
I updated to:
Android Studio Meerkat Feature Drop | 2024.3.2 Patch 1

removed the starting position from pre-match and moved it match.  you can't start the match without selecting the starting position.

We still log the starting position in the "D" file for compatibility reasons (although it's blank now).  Tableau prep will need to adjust for this.

fixes #424 
resolves #424 
closes #424 
