### PR TITLE
Change to logging ONE file and keep list of files so we don't need to…

### DIFF
--- a/app/src/main/java/com/team3663/scouting_app/activities/PreMatch.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/PreMatch.java
@@ -378,7 +378,6 @@ public class PreMatch extends AppCompatActivity {
                 startActivity(GoToSubmitData);
 
                 finish();
-
                 return;
             }
 
@@ -397,8 +396,8 @@ public class PreMatch extends AppCompatActivity {
                         // The dialog is automatically dismissed when a dialog button is clicked.
                         .setPositiveButton(getString(R.string.pre_already_scouted_button_positive), (dialog, which) -> {
                             dialog.dismiss();
-                            backupLogFile(Globals.CurrentCompetitionId + "_" + Globals.CurrentMatchNumber + "_" + Globals.CurrentDeviceId + "_" + Globals.MatchTypeList.getMatchTypeShortForm(Globals.CurrentMatchType) + "_d.csv");
-                            backupLogFile(Globals.CurrentCompetitionId + "_" + Globals.CurrentMatchNumber + "_" + Globals.CurrentDeviceId + "_" + Globals.MatchTypeList.getMatchTypeShortForm(Globals.CurrentMatchType) + "_e.csv");
+                            backupLogFile(Globals.CurrentCompetitionId + "_" + Globals.CurrentMatchNumber + "_" + Globals.CurrentDeviceId + "_" + Globals.MatchTypeList.getMatchTypeShortForm(Globals.CurrentMatchType) + ".csv");
+                            Globals.FileList.remove(Globals.CurrentCompetitionId + "_" + Globals.CurrentMatchNumber + "_" + Globals.CurrentDeviceId + "_" + Globals.MatchTypeList.getMatchTypeShortForm(Globals.CurrentMatchType) + ".csv");
                             processNextButton();
                         })
 
@@ -487,11 +486,9 @@ public class PreMatch extends AppCompatActivity {
     // Output:      void
     // =============================================================================================
     private boolean isLogFileExisting() {
-        String filename_data = Globals.CurrentCompetitionId + "_" + Globals.CurrentMatchNumber + "_" + Globals.CurrentDeviceId + "_" + Globals.MatchTypeList.getMatchTypeShortForm(Globals.CurrentMatchType) + "_d.csv";
-        String filename_event = Globals.CurrentCompetitionId + "_" + Globals.CurrentMatchNumber + "_" + Globals.CurrentDeviceId + "_" + Globals.MatchTypeList.getMatchTypeShortForm(Globals.CurrentMatchType) + "_e.csv";
+        String filename = Globals.CurrentCompetitionId + "_" + Globals.CurrentMatchNumber + "_" + Globals.CurrentDeviceId + "_" + Globals.MatchTypeList.getMatchTypeShortForm(Globals.CurrentMatchType) + ".csv";
 
-        if (Globals.output_df.findFile(filename_data) != null) return true;
-        return Globals.output_df.findFile(filename_event) != null;
+        return Globals.output_df.findFile(filename) != null;
     }
 
     // =============================================================================================

--- a/app/src/main/java/com/team3663/scouting_app/activities/QRCode.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/QRCode.java
@@ -64,12 +64,9 @@ public class QRCode extends AppCompatActivity {
     // Output:      void
     // =============================================================================================
     private void InitQRData() {
-        qrFileString = new QR_FileString(Globals.CurrentCompetitionId + "_" + Globals.TransmitMatchNum + "_" + Globals.CurrentDeviceId + "_" + Globals.MatchTypeList.getMatchTypeShortForm(Globals.TransmitMatchType) + "_d.csv" + Constants.Logger.FILE_LINE_SEPARATOR +
-                getFileAsString("d") + Constants.Logger.FILE_LINE_SEPARATOR +
-                Constants.QRCode.EOF + Constants.Logger.FILE_LINE_SEPARATOR +
-                Globals.CurrentCompetitionId + "_" + Globals.TransmitMatchNum + "_" + Globals.CurrentDeviceId + "_" + Globals.MatchTypeList.getMatchTypeShortForm(Globals.CurrentMatchType) + "_e.csv" + Constants.Logger.FILE_LINE_SEPARATOR +
-                getFileAsString("e") + Constants.Logger.FILE_LINE_SEPARATOR +
-                Constants.QRCode.EOF);
+        qrFileString = new QR_FileString(Globals.CurrentCompetitionId + "_" + Globals.TransmitMatchNum + "_" + Globals.CurrentDeviceId + "_" + Globals.MatchTypeList.getMatchTypeShortForm(Globals.TransmitMatchType) + ".csv" + Constants.Logger.FILE_LINE_SEPARATOR +
+                getFileAsString() + Constants.Logger.FILE_LINE_SEPARATOR +
+                Constants.QRCode.EOF + Constants.Logger.FILE_LINE_SEPARATOR);
 
         qrCodeBinding.butPrevImage.setEnabled(false);
         qrCodeBinding.butPrevImage.setClickable(false);
@@ -209,12 +206,8 @@ public class QRCode extends AppCompatActivity {
     //                  type of file ("d" or "e") we want to convert to a string
     // Output:      String representing the entire contents of the file
     // =============================================================================================
-    public String getFileAsString(String in_Extension) {
-        // Validate we have a proper extension
-        if (!(in_Extension.equals("d") || in_Extension.equals("e")))
-            return "";
-
-        String filename = Globals.CurrentCompetitionId + "_" + Globals.TransmitMatchNum + "_" + Globals.CurrentDeviceId + "_" + Globals.MatchTypeList.getMatchTypeShortForm(Globals.TransmitMatchType) + "_" + in_Extension + ".csv";
+    public String getFileAsString() {
+        String filename = Globals.CurrentCompetitionId + "_" + Globals.TransmitMatchNum + "_" + Globals.CurrentDeviceId + "_" + Globals.MatchTypeList.getMatchTypeShortForm(Globals.TransmitMatchType) + ".csv";
         StringBuilder file_as_string = new StringBuilder();
         String line;
 

--- a/app/src/main/java/com/team3663/scouting_app/activities/SubmitData.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/SubmitData.java
@@ -13,17 +13,16 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
-import androidx.documentfile.provider.DocumentFile;
 
 import com.team3663.scouting_app.R;
 import com.team3663.scouting_app.config.Constants;
 import com.team3663.scouting_app.config.Globals;
 import com.team3663.scouting_app.databinding.SubmitDataBinding;
+import com.team3663.scouting_app.utility.Logger;
 import com.team3663.scouting_app.utility.achievements.Achievements;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -77,7 +76,7 @@ public class SubmitData extends AppCompatActivity {
     // Output:      void
     // =============================================================================================
     private void initMatchType() {
-        // Adds the items from the match type array to the list
+        // Adds the match types from the log files to the list
         ArrayAdapter<String> adp_MatchType = new ArrayAdapter<>(this, R.layout.cpr_spinner, Match_Types);
         adp_MatchType.setDropDownViewResource(R.layout.cpr_spinner_item);
         submitDataBinding.spinnerMatchType.setAdapter(adp_MatchType);
@@ -124,17 +123,17 @@ public class SubmitData extends AppCompatActivity {
         ArrayList<Integer> ret_int = new ArrayList<>();
         ArrayList<String> ret = new ArrayList<>();
 
-        // Get the list of files
-        DocumentFile[] file_list = Globals.output_df.listFiles();
-
         // If there's no files, return nothing
-        if ((file_list.length == 0)) return ret;
+        if (Globals.FileList.isEmpty()) {
+            Logger.SearchForFiles();
+            if (Globals.FileList.isEmpty()) return ret;
+        }
 
         // Parse out the match number from the filename.  If this is a "d" file from the right
         // competition (as defined in Settings) and matching device then add it to the list.
-        for (DocumentFile df : file_list) {
-            if (df.isFile() && Objects.requireNonNull(df.getName()).endsWith("_" + Globals.MatchTypeList.getMatchTypeShortForm(Globals.TransmitMatchType) + "_d.csv")) {
-                String[] file_parts = df.getName().split("_");
+        for (String file_name : Globals.FileList.keySet()) {
+            if (file_name.endsWith("_" + Globals.MatchTypeList.getMatchTypeShortForm(Globals.TransmitMatchType) + ".csv")) {
+                String[] file_parts = file_name.split("_");
                 if ((Integer.parseInt(file_parts[0]) == Globals.CurrentCompetitionId) &&
                         (Integer.parseInt(file_parts[2]) == Globals.CurrentDeviceId))
                     ret_int.add(Integer.parseInt(file_parts[1]));

--- a/app/src/main/java/com/team3663/scouting_app/config/Constants.java
+++ b/app/src/main/java/com/team3663/scouting_app/config/Constants.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class Constants {
     public static class Logger {
         // Logger Keys - Data File is written in order of the FILE_HEADER array
-        public static final String[] LOGKEY_DATA_FILE_HEADER = new String[]{"MatchType", "Shadow", "Team", "TeamScouting", "Scouter", "DidPlay", "StartGamePiece", "DidLeaveStart", "Comments", "Achievements", "StartOffset", "Start"};
+        public static final String[] LOGKEY_DATA_FILE_HEADER = new String[]{"Shadow", "Team", "TeamScouting", "Scouter", "DidPlay", "StartGamePiece", "DidLeaveStart", "Comments", "Achievements", "StartOffset", "Start"};
         public static final String LOGKEY_SHADOW_MODE = "Shadow";
         public static final String LOGKEY_ACHIEVEMENT = "Achievements";
         public static final String LOGKEY_MATCH_TYPE = "MatchType";

--- a/app/src/main/java/com/team3663/scouting_app/config/Globals.java
+++ b/app/src/main/java/com/team3663/scouting_app/config/Globals.java
@@ -61,6 +61,7 @@ public class Globals {
     public static DocumentFile base_df = null;
     public static DocumentFile input_df = null;
     public static DocumentFile output_df = null;
+    public static HashMap<String, Long> FileList = new HashMap<>();
 
     public static int TransmitMatchNum;
     public static int TransmitMatchType;


### PR DESCRIPTION
… rescan so much.

fixes #470
fixes #474
fixes #442

in general, changed all _d and _e reference to a single .csv file Keep Globals.FileList accurate (adding or removing)

SubmitData: use the FileList to generate match numbers instead of filesystem.

Constants: remove the MatchType from the header - we'll derive this from the filename.