### PR TITLE
Handle a trimmed Competition list file

### DIFF
--- a/app/src/main/java/com/team3663/scouting_app/activities/PostMatch.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/PostMatch.java
@@ -202,7 +202,7 @@ public class PostMatch extends AppCompatActivity {
             }
 
             Achievements.data_NumMatches++;
-            Achievements.data_NumMatchesByCompetition[Globals.CurrentCompetitionId]++;
+            Achievements.data_NumMatchesByCompetition.put(Globals.CurrentCompetitionId, Achievements.data_NumMatchesByCompetition.getOrDefault(Globals.CurrentCompetitionId, 0) + 1);
             if (Globals.MatchTypeList.getMatchTypeDescription(Globals.CurrentMatchType)
                     .startsWith(Constants.Achievements.EVENT_TYPE_PRACTICE)) Achievements.data_PracticeType++;
             if (Globals.MatchTypeList.getMatchTypeDescription(Globals.CurrentMatchType)

--- a/app/src/main/java/com/team3663/scouting_app/activities/Settings.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/Settings.java
@@ -124,8 +124,10 @@ public class Settings extends AppCompatActivity {
 
         // Set the selection (if there is one) to the saved one
         savedCompetitionId = Globals.sp.getInt(Constants.Prefs.COMPETITION_ID, -1);
-        if ((savedCompetitionId > -1) && (adp_Competition.getCount() > 0))
-            settingsBinding.spinnerCompetition.setSelection(adp_Competition.getPosition(Globals.CompetitionList.getCompetitionDescription(savedCompetitionId)), true);
+        if ((savedCompetitionId > -1) && (adp_Competition.getCount() > 0)) {
+            int pos = adp_Competition.getPosition(Globals.CompetitionList.getCompetitionDescription(savedCompetitionId));
+            if (pos > -1) settingsBinding.spinnerCompetition.setSelection(pos, true);
+        }
 
         // Define the actions when an item is selected.  Set text color and set description text
         settingsBinding.spinnerCompetition.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {

--- a/app/src/main/java/com/team3663/scouting_app/utility/achievements/Achievements.java
+++ b/app/src/main/java/com/team3663/scouting_app/utility/achievements/Achievements.java
@@ -5,6 +5,7 @@ import com.team3663.scouting_app.config.Globals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 
 // =================================================================================================
 // Class:       Achievements
@@ -28,7 +29,7 @@ public class Achievements {
     public static int data_Toggle_NotMoving = 0;
     public static int data_ScoreWhileDefended = 0;
     public static int data_FieldReset = 0;
-    public static int[] data_NumMatchesByCompetition = new int[Globals.CompetitionList.size() + 1];
+    public static HashMap<Integer, Integer> data_NumMatchesByCompetition = new HashMap<>();
 
     // Scouter data per match
     public static int data_match_OrphanEvents = 0;
@@ -208,7 +209,7 @@ public class Achievements {
         data_Toggle_NotMoving = 0;
         data_ScoreWhileDefended = 0;
         data_FieldReset = 0;
-        data_NumMatchesByCompetition = new int[Globals.CompetitionList.size()];
+        data_NumMatchesByCompetition.put(Globals.CurrentCompetitionId, 0);
 
         clearMatchData();
     }

--- a/app/src/main/java/com/team3663/scouting_app/utility/achievements/RuleAttendedCompetition.java
+++ b/app/src/main/java/com/team3663/scouting_app/utility/achievements/RuleAttendedCompetition.java
@@ -17,7 +17,7 @@ public class RuleAttendedCompetition implements AchievementRule {
 
         for (int compId = 0 ; compId < Globals.CompetitionList.size(); ++compId)
             if (Globals.CompetitionList.isAttended(compId) == attended)
-                sum += Achievements.data_NumMatchesByCompetition[compId];
+                sum += Achievements.data_NumMatchesByCompetition.getOrDefault(compId, 0);
 
         return sum >= threshold;
     }

--- a/app/src/main/java/com/team3663/scouting_app/utility/achievements/RuleCompetition.java
+++ b/app/src/main/java/com/team3663/scouting_app/utility/achievements/RuleCompetition.java
@@ -15,7 +15,7 @@ public class RuleCompetition implements AchievementRule {
     public boolean evaluate() {
         int sum = 0;
         for (int compId : competitionsIds)
-            sum += Achievements.data_NumMatchesByCompetition[compId];
+            sum += Achievements.data_NumMatchesByCompetition.getOrDefault(compId, 0);
         return sum >= threshold;
     }
 }


### PR DESCRIPTION
Changed the achievement data to be a HashMap rather than an index to avoid the OOB exception.  Changed all references to use the HashMap rather than the array.

Also needed to change the Settings page to handle the default/current competition no longer being in the competition list (say it was trimmed out) - before we set the spinner selection, just make sure it's a valid one.

fixes #438 