### PR TITLE
remove ID from MatchTypes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 var versionMajor = 3
 var versionMinor = 0
 var versionPatch = 0
-var versionBuild = 0
 
 android {
     namespace = "com.team3663.scouting_app"
@@ -19,7 +18,7 @@ android {
         applicationId = "com.team3663.scouting_app"
         minSdk = 30
         targetSdk = 34
-        versionCode = versionMajor * 10000 + versionMinor * 1000 + versionPatch * 100 + versionBuild
+        versionCode = versionMajor * 10000 + versionMinor * 100 + versionPatch
         versionName = "${versionMajor}.${versionMinor}.${versionPatch}"
 
         setProperty("archivesBaseName", "CPR-Scout-$versionName")

--- a/app/src/main/assets/input_data/MatchTypes.csv
+++ b/app/src/main/assets/input_data/MatchTypes.csv
@@ -1,5 +1,5 @@
-﻿Id,MatchType_ShortForm,Description
-1,p,Practice
-2,q,Qualification
-3,s,Semi-Final (Elims)
-4,f,Final
+﻿MatchType_ShortForm,Description
+p,Practice
+q,Qualification
+s,Semi-Final (Elims)
+f,Final

--- a/app/src/main/java/com/team3663/scouting_app/activities/AppLaunch.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/AppLaunch.java
@@ -56,7 +56,6 @@ public class AppLaunch extends AppCompatActivity {
                     if (Objects.requireNonNull(data).getIntExtra(Constants.Settings.RELOAD_DATA_KEY, 0) == 1) {
                         try {
                             Globals.MatchList.clear();
-                            Globals.MatchList.addMatchRowForNoMatch();
                             LoadDataFile(getString(R.string.file_matches), getString(R.string.applaunch_loading_matches), getString(R.string.applaunch_file_error_matches));
                             Thread.sleep(Constants.AppLaunch.SPLASH_SCREEN_DELAY);
                             appLaunchBinding.textStatus.setText("");
@@ -359,11 +358,11 @@ public class AppLaunch extends AppCompatActivity {
                     } else if (in_fileName.equals(getString(R.string.file_events))) {
                         Globals.EventList.addEventRow(info[0], info[1], info[3], info[2].toUpperCase(), info[4], info[5], info[6], info[8]);
                     } else if (in_fileName.equals(getString(R.string.file_match_types))) {
-                        Globals.MatchTypeList.addMatchTypeRow(info[0], info[1], info[2]);
+                        Globals.MatchTypeList.addMatchTypeRow(info[0], info[1]);
                     } else if (in_fileName.equals(getString(R.string.file_matches))) {
                         // Use only the match information that equals the competition we're in.
                         if (Integer.parseInt(info[0]) == Globals.sp.getInt(Constants.Prefs.COMPETITION_ID, -1)) {
-                            Globals.CurrentMatchType = Globals.MatchTypeList.getMatchTypeId(info[1]);
+                            Globals.CurrentMatchType = info[1];
                             Globals.MatchList.addMatchRow(info[1], info[2], info[3], info[4], info[5], info[6], info[7], info[8]);
                         }
                     } else if (in_fileName.equals(getString(R.string.file_teams))) {

--- a/app/src/main/java/com/team3663/scouting_app/activities/PreMatch.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/PreMatch.java
@@ -145,10 +145,10 @@ public class PreMatch extends AppCompatActivity {
             @Override
             public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
                 // Save off what you selected to be used until changed again
-                int newMatchType = Globals.MatchTypeList.getMatchTypeId(preMatchBinding.spinnerMatchType.getSelectedItem().toString());
+                String newMatchType = Globals.MatchTypeList.getMatchTypeShortForm(preMatchBinding.spinnerMatchType.getSelectedItem().toString());
 
-                if (newMatchType != Globals.CurrentMatchType) {
-                    Globals.CurrentMatchType = Globals.MatchTypeList.getMatchTypeId(preMatchBinding.spinnerMatchType.getSelectedItem().toString());
+                if (!Objects.equals(newMatchType, Globals.CurrentMatchType)) {
+                    Globals.CurrentMatchType = newMatchType;
                     Globals.CurrentTeamOverrideNum = "";
                     Globals.CurrentMatchNumber = 0;
                     Globals.CurrentTeamToScout = "";
@@ -428,9 +428,9 @@ public class PreMatch extends AppCompatActivity {
         // If there's an override set, add it to the spinner
         if (!Globals.CurrentTeamOverrideNum.isEmpty()) {
             if (teamsInMatch.size() == 1)
-                teamsInMatch.set(0, String.valueOf(Globals.CurrentTeamOverrideNum));
+                teamsInMatch.set(0, Globals.CurrentTeamOverrideNum);
             else
-                teamsInMatch.add(String.valueOf(Globals.CurrentTeamOverrideNum));
+                teamsInMatch.add(Globals.CurrentTeamOverrideNum);
         }
 
         // Create and apply the adapter to the spinner.

--- a/app/src/main/java/com/team3663/scouting_app/activities/SubmitData.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/SubmitData.java
@@ -24,6 +24,7 @@ import com.team3663.scouting_app.utility.achievements.Achievements;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -34,7 +35,6 @@ public class SubmitData extends AppCompatActivity {
     private SubmitDataBinding submitDataBinding;
     private static final Timer achievement_timer = new Timer();
     private static MediaPlayer media;
-    private static ArrayList<Achievements.PoppedAchievement> pop_list;
 
     @SuppressLint({"SetTextI18n", "MissingInflatedId"})
     @Override
@@ -114,9 +114,9 @@ public class SubmitData extends AppCompatActivity {
             @Override
             public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
                 // Save off what you selected to be used until changed again
-                int newMatchType = Globals.MatchTypeList.getMatchTypeId(submitDataBinding.spinnerMatchType.getSelectedItem().toString());
+                String newMatchType = Globals.MatchTypeList.getMatchTypeShortForm(submitDataBinding.spinnerMatchType.getSelectedItem().toString());
 
-                if (newMatchType != Globals.TransmitMatchType) {
+                if (!Objects.equals(newMatchType, Globals.TransmitMatchType)) {
                     Globals.TransmitMatchType = newMatchType;
                     initMatch();
                 }
@@ -258,6 +258,8 @@ public class SubmitData extends AppCompatActivity {
     // Output:      void
     // =============================================================================================
     private void initAchievements() {
+        ArrayList<Achievements.PoppedAchievement> pop_list = Achievements.popAchievements();
+
         // Keep Achievements invisible
         submitDataBinding.imageAchievement.setVisibility(View.INVISIBLE);
         submitDataBinding.textAchievementTitle.setVisibility(View.INVISIBLE);
@@ -265,8 +267,6 @@ public class SubmitData extends AppCompatActivity {
 
         media = MediaPlayer.create(this, R.raw.achievement);
         media.setVolume(1,1);
-
-        pop_list = Achievements.popAchievements();
 
         // If achievement need to be popped, first log them, and then set up a timer to show them.
         if (!pop_list.isEmpty()) {

--- a/app/src/main/java/com/team3663/scouting_app/config/Constants.java
+++ b/app/src/main/java/com/team3663/scouting_app/config/Constants.java
@@ -33,7 +33,7 @@ public class Constants {
 
     public static class PreMatch {
         public static final int NUMBER_OF_MATCH_TYPES = 4;
-        public static final int DEFAULT_MATCH_TYPE = 1;
+        public static final String DEFAULT_MATCH_TYPE = "q";
     }
 
     public static class Match {

--- a/app/src/main/java/com/team3663/scouting_app/config/Globals.java
+++ b/app/src/main/java/com/team3663/scouting_app/config/Globals.java
@@ -37,7 +37,7 @@ public class Globals {
     public static String CurrentScoutingTeam;
     public static String CurrentTeamOverrideNum;
     public static String CurrentTeamToScout;
-    public static int CurrentMatchType = Constants.PreMatch.DEFAULT_MATCH_TYPE;
+    public static String CurrentMatchType = Constants.PreMatch.DEFAULT_MATCH_TYPE;
 
     public static String CheckBoxTextPadding = "       ";
 
@@ -64,5 +64,5 @@ public class Globals {
     public static HashMap<String, Long> FileList = new HashMap<>();
 
     public static int TransmitMatchNum;
-    public static int TransmitMatchType;
+    public static String TransmitMatchType;
 }

--- a/app/src/main/java/com/team3663/scouting_app/data/MatchTypes.java
+++ b/app/src/main/java/com/team3663/scouting_app/data/MatchTypes.java
@@ -16,27 +16,13 @@ public class MatchTypes {
     }
 
     // Member Function: Add a row of match type info into the list giving the data individually
-    public void addMatchTypeRow(String in_id, String in_short_form, String in_description) {
-        matchType_list.add(new MatchTypeRow(in_id, in_short_form, in_description));
+    public void addMatchTypeRow(String in_short_form, String in_description) {
+        matchType_list.add(new MatchTypeRow(in_short_form, in_description));
     }
 
     // Member Function: return the size of the list
     public int size() {
         return matchType_list.size();
-    }
-
-    // Member Function: Get back the ShortForm for a given match type entry (needed for logging)
-    public String getMatchTypeShortForm(int in_id) {
-        String ret = "";
-
-        // Loop through the match type list to find a matching description and return the id
-        for (MatchTypeRow mtr : matchType_list) {
-            if (mtr.id == in_id) {
-                ret = mtr.short_form;
-                break;
-            }
-        }
-        return ret;
     }
 
     // Member Function: Return a string list of all records
@@ -49,14 +35,14 @@ public class MatchTypes {
         return descriptions;
     }
 
-    // Member Function: Get back the Description for a given match type entry
-    public String getMatchTypeDescription(int in_id) {
+    // Member Function: Get back the ShortForm for a given match type Description
+    public String getMatchTypeShortForm(String in_description) {
         String ret = "";
 
         // Loop through the match type list to find a matching id and return the description
         for (MatchTypeRow mtr : matchType_list) {
-            if (mtr.id == in_id) {
-                ret = mtr.description;
+            if (Objects.equals(mtr.description, in_description)) {
+                ret = mtr.short_form;
                 break;
             }
         }
@@ -77,24 +63,6 @@ public class MatchTypes {
         return ret;
     }
 
-    // Member Function: Get back the Id for a given match type entry
-    public int getMatchTypeId(String in_description) {
-        int ret = 0;
-
-        // Loop through the match type list to find a matching description and return the id
-        for (MatchTypeRow mtr : matchType_list) {
-            if (mtr.description.equals(in_description)) {
-                ret = mtr.id;
-                break;
-            }
-            if (mtr.short_form.equals(in_description)) {
-                ret = mtr.id;
-                break;
-            }
-        }
-        return ret;
-    }
-
     // Member Function: Empties out the list
     public void clear() {
         matchType_list.clear();
@@ -105,13 +73,11 @@ public class MatchTypes {
     // Description: Defines a structure/class to hold the information for each match type
     // =============================================================================================
     private static class MatchTypeRow {
-        private final int id;
         private final String short_form;
         private final String description;
 
         // Constructor with individual data
-        public MatchTypeRow(String in_id, String in_short_form, String in_description) {
-            id = Integer.parseInt(in_id);
+        public MatchTypeRow(String in_short_form, String in_description) {
             short_form = in_short_form;
             description = in_description;
         }

--- a/app/src/main/java/com/team3663/scouting_app/data/Matches.java
+++ b/app/src/main/java/com/team3663/scouting_app/data/Matches.java
@@ -1,9 +1,9 @@
 package com.team3663.scouting_app.data;
 
-import com.team3663.scouting_app.config.Constants;
 import com.team3663.scouting_app.config.Globals;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 // =============================================================================================
 // Class:       Matches
@@ -13,61 +13,56 @@ import java.util.ArrayList;
 //              that type.
 // =============================================================================================
 public class Matches {
-    private final ArrayList<MatchesForType> match_list;
+    private final HashMap<String, MatchesForType> match_list;
 
     // Constructor
     public Matches(){
         // We need to add a whole match list for each type of matches
-        match_list = new ArrayList<>();
-        for (int i = 0; i < Constants.PreMatch.NUMBER_OF_MATCH_TYPES; ++i) {
-            match_list.add(new MatchesForType());
-        }
-    }
-
-    // Member Function: Add a row of match info into the list giving the data in a csv format
-    public void addMatchRowForNoMatch() {
-        match_list.get(Globals.CurrentMatchType - 1).addMatchRowForNoMatch();
+        match_list = new HashMap<>();
     }
 
     // Member Function: Add a row of match info into the list giving the individual data
     public void addMatchRow(String in_match_type_short_form, String in_MatchNum, String in_red1, String in_red2, String in_red3, String in_blue1, String in_blue2, String in_blue3) {
-        int match_type = Globals.MatchTypeList.getMatchTypeId(in_match_type_short_form);
-
-        for (int i = Globals.MatchList.size(); i < Integer.parseInt(in_MatchNum); i++) {
-            match_list.get(match_type - 1).addMatchRowForNoMatch();
+        if (match_list.get(in_match_type_short_form) == null) {
+            match_list.put(in_match_type_short_form, new MatchesForType());
         }
 
-        if (Integer.parseInt(in_MatchNum) < match_list.get(match_type - 1).size())
-            match_list.get(match_type - 1).setMatchRow(in_MatchNum, in_red1, in_red2, in_red3, in_blue1, in_blue2, in_blue3);
-        else
-            match_list.get(match_type - 1).addMatchRow(in_red1, in_red2, in_red3, in_blue1, in_blue2, in_blue3);
+        MatchesForType mft = match_list.get(in_match_type_short_form);
+        if (mft == null) return;
+        mft.addMatchRow(in_MatchNum, in_red1, in_red2, in_red3, in_blue1, in_blue2, in_blue3);
     }
 
     // Member Function: do we have valid match data for this one
     public boolean isCurrentMatchValid() {
-        return match_list.get(Globals.CurrentMatchType - 1).isCurrentMatchValid();
+        MatchesForType mft = match_list.get(Globals.CurrentMatchType);
+        if (mft == null) return false;
+
+        return mft.isCurrentMatchValid();
     }
 
     // Member Function: Return a list of team numbers for this match (must be set in Globals.CurrentMatchNumber)
     public ArrayList<String> getListOfTeams() {
-        return match_list.get(Globals.CurrentMatchType - 1).getListOfTeams();
+        MatchesForType mft = match_list.get(Globals.CurrentMatchType);
+        if (mft == null) return new ArrayList<>();
+
+        return mft.getListOfTeams();
     }
 
     // Member Function: Return the team that is in a certain position
     public String getTeamInPosition(String in_position) {
-        return match_list.get(Globals.CurrentMatchType - 1).getTeamInPosition(in_position);
-    }
+        MatchesForType mft = match_list.get(Globals.CurrentMatchType);
+        if (mft == null) return "";
 
-    // Member Function: Return the size of the list of Matches
-    public int size() {
-        return match_list.get(Globals.CurrentMatchType - 1).size();
+        return mft.getTeamInPosition(in_position);
     }
 
     // Member Function: Empties out the list
     public void clear() {
-        for (int i = 0; i < match_list.size(); ++i) {
-            match_list.get(i).clear();
+        for (MatchesForType mft : match_list.values()) {
+            mft.clear();
         }
+
+        match_list.clear();
     }
 
     // Member Function: Return the alliance that the team is on
@@ -75,16 +70,20 @@ public class Matches {
         String ret = "";
 
         if (!this.isCurrentMatchValid()) return ret;
-        int currMatch = Globals.CurrentMatchNumber;
+        MatchesForType mft = match_list.get(Globals.CurrentMatchType);
+        if (mft == null) return ret;
+        if (!mft.isCurrentMatchValid()) return ret;
+        MatchesForType.MatchInfoRow mir = mft.match_list_for_type.get(Globals.CurrentMatchNumber);
+        if (mir == null) return ret;
 
-        if (in_Team.equals(match_list.get(Globals.CurrentMatchType - 1).match_list_for_type.get(currMatch).blue1) ||
-                in_Team.equals(match_list.get(Globals.CurrentMatchType - 1).match_list_for_type.get(currMatch).blue2) ||
-                in_Team.equals(match_list.get(Globals.CurrentMatchType - 1).match_list_for_type.get(currMatch).blue3)) {
+        if (in_Team.equals(mir.blue1) ||
+                in_Team.equals(mir.blue2) ||
+                in_Team.equals(mir.blue3)) {
             ret = "BLUE";
         }
-        else if (in_Team.equals(match_list.get(Globals.CurrentMatchType - 1).match_list_for_type.get(currMatch).red1) ||
-                    in_Team.equals(match_list.get(Globals.CurrentMatchType - 1).match_list_for_type.get(currMatch).red2) ||
-                    in_Team.equals(match_list.get(Globals.CurrentMatchType - 1).match_list_for_type.get(currMatch).red3)) {
+        else if (in_Team.equals(mir.red1) ||
+                    in_Team.equals(mir.red2) ||
+                    in_Team.equals(mir.red3)) {
             ret = "RED";
         }
 
@@ -96,31 +95,21 @@ public class Matches {
     // Description: Defines a structure/class to hold the information for all Matches
     // =============================================================================================
     public static class MatchesForType {
-        private final ArrayList<MatchInfoRow> match_list_for_type;
+        private final HashMap<Integer,MatchInfoRow> match_list_for_type;
 
         // Constructor
         public MatchesForType() {
-            match_list_for_type = new ArrayList<>();
-        }
-
-        // Member Function: Add a row of match info into the list giving the data in a csv format
-        public void addMatchRowForNoMatch() {
-            match_list_for_type.add(new MatchInfoRow());
-        }
-
-        // Member Function: Add a row of match info into the list giving the data individually
-        public void addMatchRow(String in_red1, String in_red2, String in_red3, String in_blue1, String in_blue2, String in_blue3) {
-            match_list_for_type.add(new MatchInfoRow(in_red1, in_red2, in_red3, in_blue1, in_blue2, in_blue3));
+            match_list_for_type = new HashMap<>();
         }
 
         // Member Function: Set a row of match info into the list giving the data individually
-        public void setMatchRow(String in_MatchNum, String in_red1, String in_red2, String in_red3, String in_blue1, String in_blue2, String in_blue3) {
-            match_list_for_type.set(Integer.parseInt(in_MatchNum), new MatchInfoRow(in_red1, in_red2, in_red3, in_blue1, in_blue2, in_blue3));
+        public void addMatchRow(String in_MatchNum, String in_red1, String in_red2, String in_red3, String in_blue1, String in_blue2, String in_blue3) {
+            match_list_for_type.put(Integer.parseInt(in_MatchNum), new MatchInfoRow(in_red1, in_red2, in_red3, in_blue1, in_blue2, in_blue3));
         }
 
         // Member Function: do we have valid match data for this one
         public boolean isCurrentMatchValid() {
-            return (Globals.CurrentMatchNumber > 0) && (Globals.CurrentMatchNumber < match_list_for_type.size());
+            return(match_list_for_type.get(Globals.CurrentMatchNumber) != null);
         }
 
         // Member Function: Return a list of team numbers for this match (must be set in Globals.CurrentMatchNumber)
@@ -129,12 +118,16 @@ public class Matches {
 
             if (this.isCurrentMatchValid()) {
                 int currMatch = Globals.CurrentMatchNumber;
-                ret.add(match_list_for_type.get(currMatch).red1);
-                ret.add(match_list_for_type.get(currMatch).red2);
-                ret.add(match_list_for_type.get(currMatch).red3);
-                ret.add(match_list_for_type.get(currMatch).blue1);
-                ret.add(match_list_for_type.get(currMatch).blue2);
-                ret.add(match_list_for_type.get(currMatch).blue3);
+                MatchInfoRow mir = match_list_for_type.get(currMatch);
+
+                if (mir != null){
+                    ret.add(mir.red1);
+                    ret.add(mir.red2);
+                    ret.add(mir.red3);
+                    ret.add(mir.blue1);
+                    ret.add(mir.blue2);
+                    ret.add(mir.blue3);
+                }
             }
 
             return ret;
@@ -146,31 +139,33 @@ public class Matches {
 
             if (!this.isCurrentMatchValid()) return ret;
             int currMatch = Globals.CurrentMatchNumber;
+            MatchInfoRow mir = match_list_for_type.get(currMatch);
+            if (mir == null) return ret;
 
             switch (in_position.toUpperCase()) {
                 case "BLUE 1":
                 case "BLUE1":
-                    ret = match_list_for_type.get(currMatch).blue1;
+                    ret = mir.blue1;
                     break;
                 case "BLUE 2":
                 case "BLUE2":
-                    ret = match_list_for_type.get(currMatch).blue2;
+                    ret = mir.blue2;
                     break;
                 case "BLUE 3":
                 case "BLUE3":
-                    ret = match_list_for_type.get(currMatch).blue3;
+                    ret = mir.blue3;
                     break;
                 case "RED 1":
                 case "RED1":
-                    ret = match_list_for_type.get(currMatch).red1;
+                    ret = mir.red1;
                     break;
                 case "RED 2":
                 case "RED2":
-                    ret = match_list_for_type.get(currMatch).red2;
+                    ret = mir.red2;
                     break;
                 case "RED 3":
                 case "RED3":
-                    ret = match_list_for_type.get(currMatch).red3;
+                    ret = mir.red3;
                     break;
             }
 


### PR DESCRIPTION
Since we used an ArrayList and the ID as the index, we lost that ability.   So i converted this to a HashMap and then Matches became a HashMap of HashMaps.  So a lot of code changed to do the same thing but with a HashMap.  It meant we didn't need some functions convering MatchTypeId's and we didn't need a "NoMatch" record since the HashMap doesn't care about that.
Also added in a bunch of "Null" checks.

In Submitdata: also moved pop_list to a local variable - should have done this in a previous merge when fixing how we pop achievements.  Not an error, just a compiler warning and cleaner code.

Also changed the App versioning in build.gradle.kts to drop the "Build Version" and allow for 2-digits for Minor and Patch values.

fixes #485