### PR TITLE
Fix incorrect logging of files

### DIFF
--- a/app/src/main/java/com/team3663/scouting_app/activities/PostMatch.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/PostMatch.java
@@ -181,7 +181,7 @@ public class PostMatch extends AppCompatActivity {
         postMatchBinding.butNext.setOnClickListener(view -> {
             // If we need to reset the match, abort it all and go back
             if (postMatchBinding.checkboxReset.isChecked()) {
-                Globals.EventLogger.clear();
+                Globals.EventLogger.close();
                 Achievements.data_FieldReset++;
 
                 Intent GoToPreMatch = new Intent(PostMatch.this, PreMatch.class);

--- a/app/src/main/java/com/team3663/scouting_app/activities/PreMatch.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/PreMatch.java
@@ -84,7 +84,7 @@ public class PreMatch extends AppCompatActivity {
     // =============================================================================================
     private void initMatchNumber() {
         if (Globals.CurrentMatchNumber > 0)
-            // MUST CONVERT TO STRING or it crashes with out warning
+            // MUST CONVERT TO STRING or it crashes without warning
             preMatchBinding.editMatch.setText(String.valueOf(Globals.CurrentMatchNumber));
         else
             preMatchBinding.editMatch.setText("");
@@ -102,7 +102,7 @@ public class PreMatch extends AppCompatActivity {
                 if (MatchNumStr.isEmpty()) {
                     // Disable the override
                     preMatchBinding.checkboxOverride.setEnabled(false);
-                    Globals.CurrentMatchNumber = -1;
+                    Globals.CurrentMatchNumber = 0;
                     Globals.CurrentTeamOverrideNum = "";
                     CurrentTeamToScoutPosition = -1;
                 } else if (MatchNum != Globals.CurrentMatchNumber) {
@@ -318,7 +318,7 @@ public class PreMatch extends AppCompatActivity {
         // Set up the Logger
         // Clear and null it out first if we have one set up already (could be there if BACK button was hit on Match)
         if (Globals.EventLogger != null) {
-            Globals.EventLogger.clear();
+            Globals.EventLogger.close();
             Globals.EventLogger = null;
         }
         Globals.EventLogger = new Logger(getApplicationContext());
@@ -371,6 +371,12 @@ public class PreMatch extends AppCompatActivity {
                 // it will increment it for the "next match" will set it back (in this case) to the
                 // original value.
                 Globals.CurrentMatchNumber--;
+
+                // Since we're only resubmitting data, we should close the current logger
+                if (Globals.EventLogger != null) {
+                    Globals.EventLogger.close();
+                    Globals.EventLogger = null;
+                }
 
                 Intent GoToSubmitData = new Intent(PreMatch.this, SubmitData.class);
                 startActivity(GoToSubmitData);

--- a/app/src/main/java/com/team3663/scouting_app/activities/SubmitData.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/SubmitData.java
@@ -55,6 +55,7 @@ public class SubmitData extends AppCompatActivity {
 
         // We're done with the logger (only if not null - it can be null if we're resubmitting data from Pre-Match)
         if (Globals.EventLogger != null) {
+            Globals.EventLogger.WriteOutFiles();
             Globals.EventLogger.close();
             Globals.EventLogger = null;
         }

--- a/app/src/main/java/com/team3663/scouting_app/utility/Logger.java
+++ b/app/src/main/java/com/team3663/scouting_app/utility/Logger.java
@@ -30,6 +30,7 @@ public class Logger {
     // Keep track of the previous sequence number (per event group) so we know how to link a subsequent
     // event for that group.  Helps tremendously with UNDO actions.  This is updated / used by the logger.
     private static final int[] previous_seq = new int[Globals.MaxEventGroups + 1];
+    private static String filename = "";
 
     // Public Global Variables
     // Keep track of the currently selected event (per event group) to be used to build the context menus
@@ -46,28 +47,22 @@ public class Logger {
         Arrays.fill(previous_seq, -1);
 
         // Ensure the things are reset
-        this.clear();
+        this.close();
 
         // If this is a practice, just exit
         if (Globals.isPractice) return;
+
+        // Define the filename/file to be used for this logger
+        filename = Globals.CurrentCompetitionId + "_" + Globals.CurrentMatchNumber + "_" + Globals.CurrentDeviceId + "_" + Globals.MatchTypeList.getMatchTypeShortForm(Globals.CurrentMatchType) + ".csv";
 
         // Add an empty logging row so that Seq# is the same as the index
         match_log_events.add(new LoggerEventRow(-1, 0, 0, 0, ""));
     }
 
-    // Member Function: Clear out any saved data from the logger.
-    public void clear() {
-        match_log_events.clear();
-        match_log_data.clear();
-    }
-
-    // Member Function: Close out the logger.  Write out all of the non-time based match data and close the files.
-    public void close() {
+    // Member Function: Write out all of the match data to disk.
+    public void WriteOutFiles() {
         // If this is a practice, there's nothing to do
         if (Globals.isPractice) return;
-
-        // Define the filename/file to be used for this logger
-        String filename = Globals.CurrentCompetitionId + "_" + Globals.CurrentMatchNumber + "_" + Globals.CurrentDeviceId + "_" + Globals.MatchTypeList.getMatchTypeShortForm(Globals.CurrentMatchType) + ".csv";
 
         // If the FileList is empty, assume we haven't checked for files and do so now.
         if (Globals.FileList.isEmpty()) SearchForFiles();
@@ -115,6 +110,7 @@ public class Logger {
         WriteOutEventFile(fos);
 
         try {
+            assert fos != null;
             fos.flush();
             fos.close();
             System.gc();
@@ -124,7 +120,12 @@ public class Logger {
         }
 
         Globals.FileList.put(match_df.getName(), match_df.lastModified());
-        this.clear();
+    }
+
+    // Member Function: Close out the logger.
+    public void close() {
+        match_log_events.clear();
+        match_log_data.clear();
     }
 
     // Member Function: Search the output directory for any existing files.


### PR DESCRIPTION
Logger: split out "Writing of files" from "Closing the logger".  So we can "close" the logger without writing out files.

in addition, save off filename to be used when the logger is instantiated (in constructor) rather than at the end when writing out files.  Although this bug isn't an issue with the other fixes, it's still better to determine the filename upfront.

We don't need the "clear()" logger function now, as this is what close() does.

The "assert" line is just to get rid of a compiler warning.

PreMatch - if we're going to the SubmitData page because of a reset, CLOSE the logger first.  (then in submitdata we won't write anything out because the logger doesn't exist.

fixes #457