### PR TITLE
Fix

### DIFF
--- a/app/src/main/java/com/team3663/scouting_app/activities/SubmitData.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/SubmitData.java
@@ -148,7 +148,7 @@ public class SubmitData extends AppCompatActivity {
         // Parse out the match number from the filename.  If this is a "d" file from the right
         // competition (as defined in Settings) and matching device then add it to the list.
         for (String file_name : Globals.FileList.keySet()) {
-            if (file_name.endsWith("_" + Globals.MatchTypeList.getMatchTypeShortForm(Globals.TransmitMatchType) + ".csv")) {
+            if (file_name.endsWith("_" + Globals.TransmitMatchType + ".csv")) {
                 String[] file_parts = file_name.split("_");
                 if ((Integer.parseInt(file_parts[0]) == Globals.CurrentCompetitionId) &&
                         (Integer.parseInt(file_parts[2]) == Globals.CurrentDeviceId))
@@ -270,7 +270,9 @@ public class SubmitData extends AppCompatActivity {
         media.setVolume(1,1);
 
         // If achievement need to be popped, first log them, and then set up a timer to show them.
-        if (!pop_list.isEmpty()) {
+        // If the logger doesn't exist, wait to pop the achievement until we do. (next match?)
+        // Because we try to log the achievement which will fail if there's no valid logger.
+        if (!pop_list.isEmpty() && Globals.EventLogger != null) {
             StringBuilder ach_sep_ID = new StringBuilder();
 
             for (int achievement_index = 0; achievement_index < pop_list.size(); achievement_index++) {

--- a/app/src/main/java/com/team3663/scouting_app/utility/Logger.java
+++ b/app/src/main/java/com/team3663/scouting_app/utility/Logger.java
@@ -53,7 +53,7 @@ public class Logger {
         if (Globals.isPractice) return;
 
         // Define the filename/file to be used for this logger
-        filename = Globals.CurrentCompetitionId + "_" + Globals.CurrentMatchNumber + "_" + Globals.CurrentDeviceId + "_" + Globals.MatchTypeList.getMatchTypeShortForm(Globals.CurrentMatchType) + ".csv";
+        filename = Globals.CurrentCompetitionId + "_" + Globals.CurrentMatchNumber + "_" + Globals.CurrentDeviceId + "_" + Globals.CurrentMatchType + ".csv";
 
         // Add an empty logging row so that Seq# is the same as the index
         match_log_events.add(new LoggerEventRow(-1, 0, 0, 0, ""));


### PR DESCRIPTION
Fixes #488
SubmitData: Only pop achievement if there's a valid logger. SubmitData: found bug that we need to use the TransmitMatchType directly since it's now already the shortform, and not an integer index.

Logger: found bug that we need to create the filename using the Globals.MatchType directly since it's now already the shortform, and not an integer index.