### PR TITLE
Clicking too fast crashes

### DIFF
--- a/app/src/main/java/com/team3663/scouting_app/activities/Match.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/Match.java
@@ -131,6 +131,9 @@ public class Match extends AppCompatActivity {
         if (showing_event_detail_menu) {
             int event_id = Globals.EventList.getEventId(Objects.requireNonNull(in_item.getTitle()).toString());
 
+            // If we get called with no valid event, just return
+            if (event_id == Constants.Events.ID_NO_EVENT) return true;
+
             if (!Globals.isPractice) setEventStatus(event_id);
 
             Globals.EventLogger.LogEvent(event_id, current_X_Relative, current_Y_Relative, currentTouchTime);

--- a/app/src/main/java/com/team3663/scouting_app/activities/Settings.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/Settings.java
@@ -252,7 +252,7 @@ public class Settings extends AppCompatActivity {
     // =============================================================================================
     private void initScoutingTeam() {
         // MUST CONVERT TO STRING or it crashes with out warning
-        settingsBinding.editScoutingTeam.setText(String.valueOf(Globals.sp.getInt(Constants.Prefs.SCOUTING_TEAM, -1)));
+        settingsBinding.editScoutingTeam.setText(Globals.sp.getString(Constants.Prefs.SCOUTING_TEAM, ""));
 
         // Define a text box for the name of the Team to appear in when you enter the Number
         String ScoutingTeamNumStr = String.valueOf(settingsBinding.editScoutingTeam.getText());

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.0"
+agp = "8.13.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"


### PR DESCRIPTION
fixes #456
Match: add a check for a "no event" and return gracefully.  If you click too fast, we can call this with the default "no event id" (=999) and getting the group ID for that is -1, which will cause an OOB later in the function.  We'll get here if we can't match the text of the event to an ID (which can happen if you click too fast, and we get a timing issue where what you clicked on ("L4"?) is no longer in the list of available events ('cause you click on another menu too fast).

Settings: also noticed this line was still expecting an INT for scouting team when it's saved as a string.  Going back into Settings crashed.  Missed change from earlier check-in.

Updated gradle to 8.13.1