### PR TITLE
Fix issue with buttons "freezing" on grey color

### DIFF
--- a/app/src/main/java/com/team3663/scouting_app/activities/MatchTally.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/MatchTally.java
@@ -788,6 +788,14 @@ public class MatchTally extends AppCompatActivity {
     private void setRobotLocation(float in_X, float in_Y) {
         float offset = (float) (matchBinding.textRobot.getWidth() / 2);
 
+        // Force all action buttons to be un-pressed
+        handleActionButtonTouch(ID_BUT_CLIMB, MotionEvent.ACTION_UP);
+        handleActionButtonTouch(ID_BUT_PICKUP, MotionEvent.ACTION_UP);
+        handleActionButtonTouch(ID_BUT_PASS, MotionEvent.ACTION_UP);
+        handleActionButtonTouch(ID_BUT_PASS_TAP, MotionEvent.ACTION_UP);
+        handleActionButtonTouch(ID_BUT_SHOOT, MotionEvent.ACTION_UP);
+        handleActionButtonTouch(ID_BUT_SHOOT_TAP, MotionEvent.ACTION_UP);
+
         // If we don't know the alliance (didn't have match schedule?) then default to the PREFERRED position
         boolean blue_alliance = team_alliance.substring(0,1).equalsIgnoreCase("B");
 


### PR DESCRIPTION
fixes #587 

Now that we change the color of the button while pressed, it's possible to lock the color to grey if you hold it down and then click on a neutral or opponent zone (or in auto, place the robot there).  Doing so will disable the buttons which means the onTouch listener isn't called for the UP action.

So, just force the color "as if" the UP action was called.