### PR TITLE
add validation checks for scouter name

### DIFF
--- a/app/src/main/java/com/team3663/scouting_app/activities/PreMatch.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/PreMatch.java
@@ -428,6 +428,16 @@ public class PreMatch extends AppCompatActivity {
                 return;
             }
 
+            if (!preMatchBinding.editScouterName.getText().toString().matches("^[a-zA-Z0-9_ .]+$")) {
+                Toast.makeText(PreMatch.this, R.string.pre_name_invalid, Toast.LENGTH_SHORT).show();
+                return;
+            }
+
+            if (preMatchBinding.editScouterName.getText().toString().length() > Constants.PreMatch.MAX_SCOUTER_LENGTH) {
+                Toast.makeText(PreMatch.this, getString(R.string.pre_name_too_long).replace("!#!", String.valueOf(Constants.PreMatch.MAX_SCOUTER_LENGTH)), Toast.LENGTH_SHORT).show();
+                return;
+            }
+
             if (isLogFileExisting()) {
                 new AlertDialog.Builder(view.getContext())
                         .setTitle(getString(R.string.pre_already_scouted_title))

--- a/app/src/main/java/com/team3663/scouting_app/config/Constants.java
+++ b/app/src/main/java/com/team3663/scouting_app/config/Constants.java
@@ -40,6 +40,7 @@ public class Constants {
     public static class PreMatch {
         public static final String DEFAULT_MATCH_TYPE = "q";
         public static final int STARTING_GAME_PIECES = 8;
+        public static final int MAX_SCOUTER_LENGTH = 20;
     }
 
     public static class Match {

--- a/app/src/main/res/values/strings_pre_match.xml
+++ b/app/src/main/res/values/strings_pre_match.xml
@@ -19,4 +19,6 @@
     <string name="pre_already_scouted_message">Do you want to continue and overwrite the previous scouting data or go back and change the match?</string>
     <string name="pre_already_scouted_button_positive">Continue</string>
     <string name="pre_already_scouted_button_negative">Cancel</string>
+    <string name="pre_name_invalid">Scouter name can only contain letters, numbers, spaces, periods and underscores</string>
+    <string name="pre_name_too_long">Scouter name must be no more than !#! characters</string>
 </resources>


### PR DESCRIPTION
limit to 20 characters and limit characters to:
upper/lower case letters
numbers
underscore, space or period.