### PR TITLE
Fix Bug

### DIFF
--- a/app/src/main/java/com/team3663/scouting_app/activities/AppLaunch.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/AppLaunch.java
@@ -120,12 +120,6 @@ public class AppLaunch extends AppCompatActivity {
         initSettings();
         initScouting();
 
-        // Set the constant values - 2026 Season
-        Constants.Events.IDS_TO_COLLAPSE.add(3);
-        Constants.Events.IDS_TO_COLLAPSE.add(5);
-        Constants.Events.IDS_TO_COLLAPSE.add(21);
-        Constants.Events.IDS_TO_COLLAPSE.add(23);
-
         Animation fadeIn = AnimationUtils.loadAnimation(this, R.anim.fade_in);
         appLaunchBinding.textBanner.startAnimation(fadeIn);
 

--- a/app/src/main/java/com/team3663/scouting_app/config/Constants.java
+++ b/app/src/main/java/com/team3663/scouting_app/config/Constants.java
@@ -107,7 +107,6 @@ public class Constants {
         public static final int ID_AUTO_START_GAME_PIECE = 0;
         public static final int ID_AUTO_CLIMB = 6;
         public static final int ID_TELE_CLIMB = 40;
-        public static final Set<Integer> IDS_TO_COLLAPSE = new HashSet<>();
         public static final int ID_NO_EVENT = 999;   // use to check if the eventID you're looking for doesn't exist
     }
 

--- a/app/src/main/java/com/team3663/scouting_app/utility/Logger.java
+++ b/app/src/main/java/com/team3663/scouting_app/utility/Logger.java
@@ -185,6 +185,7 @@ public class Logger {
     private void WriteOutEventFile(OutputStream in_fos) {
         int count = 0;
         boolean repeatedRow = false;
+        int rowsCollapsed = 0;
 
         // Form the output line that goes in the csv file.
         for (int i = 1; i < match_log_events.size(); ++i) {
@@ -222,6 +223,7 @@ public class Logger {
 
             if (repeatedRow) {
                 count += next_ler.Count;
+                rowsCollapsed++;
             } else {
                 StringBuilder csv_line = new StringBuilder();
                 csv_line.append("E")
@@ -229,7 +231,7 @@ public class Logger {
                         .append(",").append(Globals.CurrentMatchType)
                         .append(",").append(Globals.CurrentMatchNumber)
                         .append(",").append(Globals.CurrentTeamToScout)
-                        .append(",").append(i)
+                        .append(",").append(i - rowsCollapsed)
                         .append(",").append(ler.EventId)
                         .append(",").append(ler.LogTime)
                         .append(",").append(normalized_x)
@@ -243,6 +245,16 @@ public class Logger {
                 } catch (IOException e) {
                     Toast.makeText(appContext, "Failed to write out event data: " + csv_line + " (ERROR: " + e.getMessage() + ")", Toast.LENGTH_LONG).show();
                     throw new RuntimeException(e);
+                }
+
+                // If we collapsed any rows, see if any future records point to this row, and if so, subtract the count
+                if (rowsCollapsed > 0) {
+                    for (int j = i + 1; j < match_log_events.size(); ++j) {
+                        if (match_log_events.get(j).PrevSeq.equals(String.valueOf(i))) {
+                            match_log_events.get(j).PrevSeq = String.valueOf(i - rowsCollapsed);
+                            break;
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/team3663/scouting_app/utility/Logger.java
+++ b/app/src/main/java/com/team3663/scouting_app/utility/Logger.java
@@ -189,6 +189,9 @@ public class Logger {
         // Form the output line that goes in the csv file.
         for (int i = 1; i < match_log_events.size(); ++i) {
             LoggerEventRow ler = match_log_events.get(i);
+            LoggerEventRow next_ler = ler;
+
+            if (i < match_log_events.size() - 1) next_ler = match_log_events.get(i + 1);
 
             if (!repeatedRow) count = ler.Count;
             repeatedRow = false;
@@ -203,22 +206,22 @@ public class Logger {
 
             // Peak ahead and if the next event is the same (and in the same "zone") combine the two events into one.
             // Don't do this for AUTO phase since we want the fidelity.
-            if ((i < match_log_events.size() - 1) && Constants.Events.IDS_TO_COLLAPSE.contains(ler.EventId) &&
-                    !Globals.EventList.getPhaseForEvent(ler.EventId).equals(Constants.Phases.AUTO)) {
-                LoggerEventRow next_ler = match_log_events.get(i + 1);
-
-                if (ler.EventId == next_ler.EventId) {
+            if ((i < match_log_events.size() - 1) && (ler.EventId == next_ler.EventId)) {
+                if (!Globals.EventList.getPhaseForEvent(ler.EventId).equals(Constants.Phases.AUTO))
+                {
                     if ((ler.X < MatchTally.NeutralZone_StartX) && (next_ler.X < MatchTally.NeutralZone_StartX))
                         repeatedRow = true;
-                    else if ((ler.X < MatchTally.RightZone_StartX) && (next_ler.X < MatchTally.RightZone_StartX))
+                    else if ((ler.X < MatchTally.RightZone_StartX) && (next_ler.X < MatchTally.RightZone_StartX) && (ler.X >= MatchTally.NeutralZone_StartX) && (next_ler.X >= MatchTally.NeutralZone_StartX))
                         repeatedRow = true;
                     else if ((ler.X >= MatchTally.RightZone_StartX) && (next_ler.X >= MatchTally.RightZone_StartX))
                         repeatedRow = true;
+                } else if (Globals.EventList.getPhaseForEvent(ler.EventId).equals(Constants.Phases.AUTO)) {
+                    if (ler.X == next_ler.X && ler.Y == next_ler.Y) repeatedRow = true;
                 }
             }
 
             if (repeatedRow) {
-                count++;
+                count += next_ler.Count;
             } else {
                 StringBuilder csv_line = new StringBuilder();
                 csv_line.append("E")

--- a/app/src/main/java/com/team3663/scouting_app/utility/Logger.java
+++ b/app/src/main/java/com/team3663/scouting_app/utility/Logger.java
@@ -10,7 +10,6 @@ import com.team3663.scouting_app.R;
 import com.team3663.scouting_app.activities.MatchTally;
 import com.team3663.scouting_app.config.Constants;
 import com.team3663.scouting_app.config.Globals;
-import com.team3663.scouting_app.databinding.MatchTallyBinding;
 import com.team3663.scouting_app.utility.achievements.Achievements;
 
 import java.io.IOException;
@@ -186,6 +185,8 @@ public class Logger {
         int count = 0;
         boolean repeatedRow = false;
         int rowsCollapsed = 0;
+        String shift;
+        String shift_next;
 
         // Form the output line that goes in the csv file.
         for (int i = 1; i < match_log_events.size(); ++i) {
@@ -193,6 +194,24 @@ public class Logger {
             LoggerEventRow next_ler = ler;
 
             if (i < match_log_events.size() - 1) next_ler = match_log_events.get(i + 1);
+
+            // Determine the shift that the event happened in.
+            if (ler.LogTime <= 200) shift = "AUTO";
+            else if (ler.LogTime <= 300) shift = "TRANSITION";
+            else if (ler.LogTime <= 550) shift = "SHIFT1";
+            else if (ler.LogTime <= 800) shift = "SHIFT2";
+            else if (ler.LogTime <= 1050) shift = "SHIFT3";
+            else if (ler.LogTime <= 1300) shift = "SHIFT4";
+            else shift = "ENDGAME";
+
+            // Determine the shift that the next event happened in.
+            if (next_ler.LogTime <= 200) shift_next = "AUTO";
+            else if (next_ler.LogTime <= 300) shift_next = "TRANSITION";
+            else if (next_ler.LogTime <= 550) shift_next = "SHIFT1";
+            else if (next_ler.LogTime <= 800) shift_next = "SHIFT2";
+            else if (next_ler.LogTime <= 1050) shift_next = "SHIFT3";
+            else if (next_ler.LogTime <= 1300) shift_next = "SHIFT4";
+            else shift_next = "ENDGAME";
 
             if (!repeatedRow) count = ler.Count;
             repeatedRow = false;
@@ -205,9 +224,8 @@ public class Logger {
             if (Constants.Match.IMAGE_WIDTH > 0) normalized_x = (int)(10_000.0 * ler.X / Constants.Match.IMAGE_WIDTH);
             if (Constants.Match.IMAGE_HEIGHT > 0) normalized_y = (int)(10_000.0 * ler.Y / Constants.Match.IMAGE_HEIGHT);
 
-            // Peak ahead and if the next event is the same (and in the same "zone") combine the two events into one.
-            // Don't do this for AUTO phase since we want the fidelity.
-            if ((i < match_log_events.size() - 1) && (ler.EventId == next_ler.EventId)) {
+            // Peak ahead and if the next event is the same (and in the same "zone" and in the same "shift") combine the two events into one.
+            if ((i < match_log_events.size() - 1) && (ler.EventId == next_ler.EventId) && (shift.equals(shift_next))) {
                 if (!Globals.EventList.getPhaseForEvent(ler.EventId).equals(Constants.Phases.AUTO))
                 {
                     if ((ler.X < MatchTally.NeutralZone_StartX) && (next_ler.X < MatchTally.NeutralZone_StartX))


### PR DESCRIPTION
fixes #609

AppLaunch: We won't collapse a small set.  ANY repeated event can be collapsed if it falls under the rules in Logger class.

Constants: don't need this anymore

Logger: We'll collapse anything in Tele if it's the same event.  For Auto, as long as the X and Y coordinate are the same, we'll collapse it, whether it's pass/shoot/pickup. Also fixed the check for the neutral zone. it wasn't complete - if LER was in AllianceZone and NEXT_LER was in neutral zone, we collapsed it before.  oops. Also increment the count by the count of the next_ler record, not just by 1 (since we're collapsing the "pass/shoot many" events now as well.